### PR TITLE
Add event name ( `event.name` ) column in the list of Logs

### DIFF
--- a/tuiexporter/internal/tui/component/log.go
+++ b/tuiexporter/internal/tui/component/log.go
@@ -40,8 +40,9 @@ func (l LogDataForTable) GetColumnCount() int {
 	// 1: ServiceName
 	// 2: Timestamp
 	// 3: Severity
-	// 4: RawData
-	return 5
+	// 4: EventName
+	// 5: RawData
+	return 6
 }
 
 // getCellFromLog returns a table cell for the given log and column.
@@ -59,6 +60,13 @@ func getCellFromLog(log *telemetry.LogData, column int) *tview.TableCell {
 	case 3:
 		text = log.Log.SeverityText()
 	case 4:
+		// see: https://github.com/open-telemetry/semantic-conventions/blob/a4fc971e0c7ffa4b9572654f075d3cb8560db770/docs/general/events.md#event-definition
+		if ename, ok := log.Log.Attributes().Get("event.name"); ok {
+			text = ename.AsString()
+		} else {
+			text = "N/A<Event Name>"
+		}
+	case 5:
 		text = log.Log.Body().AsString()
 	}
 

--- a/tuiexporter/internal/tui/component/log_test.go
+++ b/tuiexporter/internal/tui/component/log_test.go
@@ -38,6 +38,7 @@ func TestLogDataForTable(t *testing.T) {
 	//        └- log: log-1-1-1-2
 	_, testdata1 := test.GenerateOTLPLogsPayload(t, 1, 2, []int{2, 1}, [][]int{{2, 1}, {1}})
 	_, testdata2 := test.GenerateOTLPLogsPayload(t, 2, 1, []int{1}, [][]int{{1}})
+	testdata1.Logs[0].Attributes().PutStr("event.name", "device.app.lifecycle")
 	logs := &[]*telemetry.LogData{
 		{
 			Log:         testdata1.Logs[0],
@@ -87,7 +88,7 @@ func TestLogDataForTable(t *testing.T) {
 	})
 
 	t.Run("GetColumnCount", func(t *testing.T) {
-		assert.Equal(t, 5, ldftable.GetColumnCount())
+		assert.Equal(t, 6, ldftable.GetColumnCount())
 	})
 
 	t.Run("GetCell", func(t *testing.T) {
@@ -106,7 +107,7 @@ func TestLogDataForTable(t *testing.T) {
 			{
 				name:   "invalid column",
 				row:    0,
-				column: 5,
+				column: 6,
 				want:   "N/A",
 			},
 			{
@@ -114,6 +115,12 @@ func TestLogDataForTable(t *testing.T) {
 				row:    0,
 				column: 0,
 				want:   "01000000000000000000000000000000",
+			},
+			{
+				name:   "event name trace 1 span-1-1-1",
+				row:    0,
+				column: 4,
+				want:   "device.app.lifecycle",
 			},
 			{
 				name:   "service name trace 1 span-2-1-1",
@@ -134,9 +141,15 @@ func TestLogDataForTable(t *testing.T) {
 				want:   "INFO",
 			},
 			{
-				name:   "raw data trace 2 span-1-1-1",
+				name:   "event name trace 2 span-1-1-1",
 				row:    8,
 				column: 4,
+				want:   "N/A<Event Name>",
+			},
+			{
+				name:   "raw data trace 2 span-1-1-1",
+				row:    8,
+				column: 5,
 				want:   "log body 0-0-0-0",
 			},
 		}


### PR DESCRIPTION
closes: #132

Add a column of `event.name` in the list of Logs. It'll be `N/A<Event Name>` if `event.name` is not set.

Screenshot
![image](https://github.com/user-attachments/assets/aef62eef-d886-4ac6-967c-fb06bb5b607a)