### PR TITLE
Filter traces by service and span name

### DIFF
--- a/tuiexporter/internal/telemetry/store.go
+++ b/tuiexporter/internal/telemetry/store.go
@@ -140,8 +140,8 @@ func (s *Store) UpdatedAt() time.Time {
 	return s.updatedAt
 }
 
-// ApplyFilterService applies a filter to the traces
-func (s *Store) ApplyFilterService(svc string) {
+// ApplyFilterTraces applies a filter to the traces
+func (s *Store) ApplyFilterTraces(svc string) {
 	s.filterSvc = svc
 	s.svcspansFiltered = []*SpanData{}
 
@@ -151,15 +151,19 @@ func (s *Store) ApplyFilterService(svc string) {
 	}
 
 	for _, span := range s.svcspans {
-		sname, _ := span.ResourceSpan.Resource().Attributes().Get("service.name")
-		if strings.Contains(sname.AsString(), svc) {
+		sname := ""
+		if snameattr, ok := span.ResourceSpan.Resource().Attributes().Get("service.name"); ok {
+			sname = snameattr.AsString()
+		}
+		target := sname + " " + span.Span.Name()
+		if strings.Contains(target, svc) {
 			s.svcspansFiltered = append(s.svcspansFiltered, span)
 		}
 	}
 }
 
 func (s *Store) updateFilterService() {
-	s.ApplyFilterService(s.filterSvc)
+	s.ApplyFilterTraces(s.filterSvc)
 }
 
 // ApplyFilterMetrics applies a filter to the metrics

--- a/tuiexporter/internal/telemetry/store_test.go
+++ b/tuiexporter/internal/telemetry/store_test.go
@@ -68,10 +68,21 @@ func TestStoreSpanFilters(t *testing.T) {
 	traceID := testdata.Spans[0].TraceID().String()
 	store.AddSpan(&payload)
 
-	store.ApplyFilterService("service-2")
+	store.ApplyFilterTraces("0-0")
+	assert.Equal(t, 2, len(store.svcspansFiltered))
+	assert.Equal(t, traceID, store.GetTraceIDByFilteredIdx(0))
+	assert.Equal(t, traceID, store.GetTraceIDByFilteredIdx(1))
+	assert.Equal(t, "", store.GetTraceIDByFilteredIdx(2))
+	// spans in test-service-1
+	assert.Equal(t, "span-0-0-0", store.GetFilteredServiceSpansByIdx(0)[0].Span.Name())
+	assert.Equal(t, "span-0-0-1", store.GetFilteredServiceSpansByIdx(0)[1].Span.Name())
+	// spans in test-service-2
+	assert.Equal(t, "span-1-0-0", store.GetFilteredServiceSpansByIdx(1)[0].Span.Name())
+	store.ApplyFilterTraces("service-2")
 	assert.Equal(t, 1, len(store.svcspansFiltered))
 	assert.Equal(t, traceID, store.GetTraceIDByFilteredIdx(0))
 	assert.Equal(t, "", store.GetTraceIDByFilteredIdx(1))
+	assert.Equal(t, "span-1-0-0", store.GetFilteredServiceSpansByIdx(0)[0].Span.Name())
 
 	tests := []struct {
 		name string

--- a/tuiexporter/internal/tui/component/page.go
+++ b/tuiexporter/internal/tui/component/page.go
@@ -176,7 +176,7 @@ func (p *TUIPages) createTracePage(store *telemetry.Store) *tview.Flex {
 	input := ""
 	inputConfirmed := ""
 	search := tview.NewInputField().
-		SetLabel("Service Name (/): ").
+		SetLabel("Filter by service or span name (/): ").
 		SetFieldWidth(20)
 	search.SetChangedFunc(func(text string) {
 		// remove the suffix '/' from input because it is passed from SetInputCapture()
@@ -190,7 +190,7 @@ func (p *TUIPages) createTracePage(store *telemetry.Store) *tview.Flex {
 		if key == tcell.KeyEnter {
 			inputConfirmed = input
 			log.Println("search service name: ", inputConfirmed)
-			store.ApplyFilterService(inputConfirmed)
+			store.ApplyFilterTraces(inputConfirmed)
 		} else if key == tcell.KeyEsc {
 			search.SetText(inputConfirmed)
 		}


### PR DESCRIPTION
closes: #118 

This change enables us to filter traces by span name in addition to service name.

![image](https://github.com/user-attachments/assets/b63be03f-76b4-496c-b105-279fabbcda8f)