### PR TITLE
Display keymaps corresponding to focused pane, not page

### DIFF
--- a/tuiexporter/internal/tui/component/commands.go
+++ b/tuiexporter/internal/tui/component/commands.go
@@ -1,0 +1,66 @@
+package component
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+var keyMapRegex = regexp.MustCompile(`Rune|\[|\]`)
+
+type KeyMap struct {
+	key         *tcell.EventKey
+	description string
+}
+
+type KeyMaps []*KeyMap
+
+func (m KeyMaps) keyTexts() string {
+	keytexts := []string{}
+	for _, v := range m {
+		keytexts = append(keytexts, fmt.Sprintf(" [yellow]%s[white]: %s",
+			keyMapRegex.ReplaceAllString(v.key.Name(), ""),
+			v.description,
+		))
+	}
+	return strings.Join(keytexts, " | ")
+}
+
+type Focusable interface {
+	SetFocusFunc(func()) *tview.Box
+}
+
+func newCommandList() *tview.TextView {
+	return tview.NewTextView().
+		SetDynamicColors(true)
+}
+
+func attatchCommandList(commands *tview.TextView, p tview.Primitive) *tview.Flex {
+	base := tview.NewFlex().SetDirection(tview.FlexRow)
+
+	if commands == nil {
+		return base
+	}
+
+	base.AddItem(p, 0, 1, true).
+		AddItem(commands, 1, 1, false)
+
+	return base
+}
+
+func registerCommandList(commands *tview.TextView, c Focusable, origFocusFn func(), keys KeyMaps) {
+	if commands == nil {
+		return
+	}
+
+	c.SetFocusFunc(func() {
+		commands.SetText(keys.keyTexts())
+
+		if origFocusFn != nil {
+			origFocusFn()
+		}
+	})
+}

--- a/tuiexporter/internal/tui/component/log.go
+++ b/tuiexporter/internal/tui/component/log.go
@@ -3,6 +3,7 @@ package component
 import (
 	"fmt"
 
+	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 	"github.com/ymtdzzz/otel-tui/tuiexporter/internal/telemetry"
 )
@@ -79,7 +80,7 @@ func getCellFromLog(log *telemetry.LogData, column int) *tview.TableCell {
 	return tview.NewTableCell(text)
 }
 
-func getLogInfoTree(l *telemetry.LogData, tcache *telemetry.TraceCache, drawTimelineFn func(traceID string)) *tview.TreeView {
+func getLogInfoTree(commands *tview.TextView, l *telemetry.LogData, tcache *telemetry.TraceCache, drawTimelineFn func(traceID string)) *tview.TreeView {
 	if l == nil {
 		return tview.NewTreeView()
 	}
@@ -165,6 +166,21 @@ func getLogInfoTree(l *telemetry.LogData, tcache *telemetry.TraceCache, drawTime
 
 	tree.SetSelectedFunc(func(node *tview.TreeNode) {
 		node.SetExpanded(!node.IsExpanded())
+	})
+
+	registerCommandList(commands, tree, nil, KeyMaps{
+		{
+			key:         tcell.NewEventKey(tcell.KeyRune, 'L', tcell.ModCtrl),
+			description: "Reduce the width",
+		},
+		{
+			key:         tcell.NewEventKey(tcell.KeyRune, 'H', tcell.ModCtrl),
+			description: "Expand the width",
+		},
+		{
+			key:         tcell.NewEventKey(tcell.KeyEnter, ' ', tcell.ModNone),
+			description: "Toggle folding the child nodes",
+		},
 	})
 
 	return tree

--- a/tuiexporter/internal/tui/component/log_test.go
+++ b/tuiexporter/internal/tui/component/log_test.go
@@ -182,7 +182,7 @@ func TestGetLogInfoTree(t *testing.T) {
 	screen.Init()
 	screen.SetSize(sw, sh)
 
-	gottree := getLogInfoTree(logs[0], nil, nil)
+	gottree := getLogInfoTree(nil, logs[0], nil, nil)
 	gottree.SetRect(0, 0, sw, sh)
 	gottree.Draw(screen)
 	screen.Sync()

--- a/tuiexporter/internal/tui/component/metric.go
+++ b/tuiexporter/internal/tui/component/metric.go
@@ -88,7 +88,7 @@ func getCellFromMetrics(metric *telemetry.MetricData, column int) *tview.TableCe
 	return tview.NewTableCell(text)
 }
 
-func getMetricInfoTree(m *telemetry.MetricData) *tview.TreeView {
+func getMetricInfoTree(commands *tview.TextView, m *telemetry.MetricData) *tview.TreeView {
 	if m == nil {
 		return nil
 	}
@@ -369,6 +369,21 @@ func getMetricInfoTree(m *telemetry.MetricData) *tview.TreeView {
 		node.SetExpanded(!node.IsExpanded())
 	})
 
+	registerCommandList(commands, tree, nil, KeyMaps{
+		{
+			key:         tcell.NewEventKey(tcell.KeyRune, 'L', tcell.ModCtrl),
+			description: "Reduce the width",
+		},
+		{
+			key:         tcell.NewEventKey(tcell.KeyRune, 'H', tcell.ModCtrl),
+			description: "Expand the width",
+		},
+		{
+			key:         tcell.NewEventKey(tcell.KeyEnter, ' ', tcell.ModNone),
+			description: "Toggle folding the child nodes",
+		},
+	})
+
 	return tree
 }
 
@@ -380,7 +395,7 @@ func (a ByTimestamp) Less(i, j int) bool {
 	return a[i].Timestamp().AsTime().Before(a[j].Timestamp().AsTime())
 }
 
-func drawMetricChartByRow(store *telemetry.Store, row int) tview.Primitive {
+func drawMetricChartByRow(commands *tview.TextView, store *telemetry.Store, row int) tview.Primitive {
 	m := store.GetFilteredMetricByIdx(row)
 	mcache := store.GetMetricCache()
 	sname := "N/A"
@@ -541,6 +556,8 @@ func drawMetricChartByRow(store *telemetry.Store, row int) tview.Primitive {
 	})
 
 	chart.AddItem(ch, 0, 7, true).AddItem(legend, 0, 3, false)
+
+	registerCommandList(commands, ch, nil, KeyMaps{})
 
 	return chart
 }

--- a/tuiexporter/internal/tui/component/trace.go
+++ b/tuiexporter/internal/tui/component/trace.go
@@ -82,7 +82,7 @@ func getCellFromSpan(span *telemetry.SpanData, column int) *tview.TableCell {
 	return tview.NewTableCell(text)
 }
 
-func getTraceInfoTree(spans []*telemetry.SpanData) *tview.TreeView {
+func getTraceInfoTree(commands *tview.TextView, spans []*telemetry.SpanData) *tview.TreeView {
 	if len(spans) == 0 {
 		return tview.NewTreeView()
 	}
@@ -134,6 +134,21 @@ func getTraceInfoTree(spans []*telemetry.SpanData) *tview.TreeView {
 
 	tree.SetSelectedFunc(func(node *tview.TreeNode) {
 		node.SetExpanded(!node.IsExpanded())
+	})
+
+	registerCommandList(commands, tree, nil, KeyMaps{
+		{
+			key:         tcell.NewEventKey(tcell.KeyRune, 'L', tcell.ModCtrl),
+			description: "Reduce the width",
+		},
+		{
+			key:         tcell.NewEventKey(tcell.KeyRune, 'H', tcell.ModCtrl),
+			description: "Expand the width",
+		},
+		{
+			key:         tcell.NewEventKey(tcell.KeyEnter, ' ', tcell.ModNone),
+			description: "Toggle folding the child nodes",
+		},
 	})
 
 	return tree

--- a/tuiexporter/internal/tui/component/trace_test.go
+++ b/tuiexporter/internal/tui/component/trace_test.go
@@ -148,7 +148,7 @@ func TestGetTraceInfoTree(t *testing.T) {
 	screen.Init()
 	screen.SetSize(sw, sh)
 
-	gottree := getTraceInfoTree(spans)
+	gottree := getTraceInfoTree(nil, spans)
 	gottree.SetRect(0, 0, sw, sh)
 	gottree.Draw(screen)
 	screen.Sync()
@@ -192,5 +192,5 @@ func TestGetTraceInfoTree(t *testing.T) {
 }
 
 func TestGetTraceInfoTreeNoSpans(t *testing.T) {
-	assert.Nil(t, getTraceInfoTree(nil).GetRoot())
+	assert.Nil(t, getTraceInfoTree(nil, nil).GetRoot())
 }


### PR DESCRIPTION
closes: #92

focused on the traces pane
![image](https://github.com/user-attachments/assets/876a7417-bb02-499d-be78-464040f0c6bd)

focused on the search form
![image](https://github.com/user-attachments/assets/423ed58b-8fe4-4907-975f-065ec32a9380)

focused on the timeline pane
![image](https://github.com/user-attachments/assets/4a77c3f2-0682-44d1-80ca-11353c6d2cc3)