### PR TITLE
Print the root span in details pane of traces page

### DIFF
--- a/tuiexporter/internal/telemetry/cache_test.go
+++ b/tuiexporter/internal/telemetry/cache_test.go
@@ -1,9 +1,12 @@
 package telemetry
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
 )
 
 func TestGetSpansByTraceID(t *testing.T) {
@@ -112,6 +115,87 @@ func TestGetSpanByID(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gotdata, gotok := c.GetSpanByID(tt.spanID)
+			assert.Equal(t, tt.wantdata, gotdata)
+			assert.Equal(t, tt.wantok, gotok)
+		})
+	}
+}
+
+func TestGetRootSpanByID(t *testing.T) {
+	c := NewTraceCache()
+	var (
+		spanIDA            pcommon.SpanID = [8]byte{byte(1)}
+		spanIDB            pcommon.SpanID = [8]byte{byte(2)}
+		spanIDC            pcommon.SpanID = [8]byte{byte(3)}
+		orphanParentSpanID pcommon.SpanID = [8]byte{byte(4)}
+		orphanChildSpanID  pcommon.SpanID = [8]byte{byte(5)}
+	)
+	spanA := ptrace.NewSpan()
+	spanA.SetParentSpanID(pcommon.NewSpanIDEmpty()) // root
+	spanB := ptrace.NewSpan()
+	spanB.SetParentSpanID(spanIDA) // A's child
+	spanC := ptrace.NewSpan()
+	spanC.SetParentSpanID(spanIDB) // B's child
+	spanOrphanChild := ptrace.NewSpan()
+	spanOrphanChild.SetParentSpanID(orphanParentSpanID) // non-existent parent's child
+	spanDataA := &SpanData{
+		Span: &spanA,
+	}
+	spanDataB := &SpanData{
+		Span: &spanB,
+	}
+	spanDataC := &SpanData{
+		Span: &spanC,
+	}
+	orphanChildSpanData := &SpanData{
+		Span: &spanOrphanChild,
+	}
+	c.spanid2span[spanIDA.String()] = spanDataA
+	c.spanid2span[spanIDB.String()] = spanDataB
+	c.spanid2span[spanIDC.String()] = spanDataC
+	c.spanid2span[orphanChildSpanID.String()] = orphanChildSpanData
+
+	tests := []struct {
+		name     string
+		spanID   string
+		wantdata *SpanData
+		wantok   bool
+	}{
+		{
+			"root span exists from C",
+			spanIDC.String(),
+			spanDataA,
+			true,
+		},
+		{
+			"root span exists from B",
+			spanIDB.String(),
+			spanDataA,
+			true,
+		},
+		{
+			"root span exists from A itself",
+			spanIDA.String(),
+			spanDataA,
+			true,
+		},
+		{
+			"orphan span",
+			orphanChildSpanID.String(),
+			nil,
+			false,
+		},
+		{
+			name:     "spanid does not exist",
+			spanID:   "non-existent-spanid",
+			wantdata: nil,
+			wantok:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotdata, gotok := c.GetRootSpanByID(context.Background(), tt.spanID)
 			assert.Equal(t, tt.wantdata, gotdata)
 			assert.Equal(t, tt.wantok, gotok)
 		})

--- a/tuiexporter/internal/tui/component/page.go
+++ b/tuiexporter/internal/tui/component/page.go
@@ -1,6 +1,7 @@
 package component
 
 import (
+	"context"
 	"log"
 	"strings"
 
@@ -209,13 +210,18 @@ func (p *TUIPages) createTracePage(store *telemetry.Store) *tview.Flex {
 		},
 	})
 
+	// context for searching the root span in details pane
+	rootSpanCtx, cancel := context.WithCancel(context.Background())
+
 	table.SetSelectionChangedFunc(func(row, _ int) {
+		cancel()
 		if row == 0 {
 			return
 		}
 		details.Clear()
-		details.AddItem(getTraceInfoTree(commands, store.GetFilteredServiceSpansByIdx(row-1)), 0, 1, true)
-		log.Printf("selected row(original): %d", row)
+		rootSpanCtx, cancel = context.WithCancel(context.Background())
+		details.AddItem(getTraceInfoTree(rootSpanCtx, commands, store.GetFilteredServiceSpansByIdx(row-1), store.GetTraceCache()), 0, 1, true)
+		//log.Printf("selected row(original): %d", row)
 	})
 	tableContainer.
 		AddItem(search, 1, 0, false).

--- a/tuiexporter/internal/tui/component/trace.go
+++ b/tuiexporter/internal/tui/component/trace.go
@@ -115,7 +115,6 @@ func getTraceInfoTree(ctx context.Context, commands *tview.TextView, spans []*te
 			}
 			rootSpanID.SetText(fmt.Sprintf("root span id: %s", rootSpan.Span.SpanID().String()))
 			rootSpanName.SetText(fmt.Sprintf("root span name: %s", rootSpan.Span.Name()))
-			return
 		}(ctx, rootServiceName, rootSpanID, rootSpanName, tcache)
 	}
 

--- a/tuiexporter/internal/tui/component/trace_test.go
+++ b/tuiexporter/internal/tui/component/trace_test.go
@@ -2,6 +2,7 @@ package component
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -143,12 +144,12 @@ func TestGetTraceInfoTree(t *testing.T) {
 		ResourceSpan: testdata.RSpans[1],
 		ScopeSpans:   testdata.SSpans[2],
 	})
-	sw, sh := 55, 20
+	sw, sh := 55, 24
 	screen := tcell.NewSimulationScreen("")
 	screen.Init()
 	screen.SetSize(sw, sh)
 
-	gottree := getTraceInfoTree(nil, spans)
+	gottree := getTraceInfoTree(context.Background(), nil, spans, nil)
 	gottree.SetRect(0, 0, sw, sh)
 	gottree.Draw(screen)
 	screen.Sync()
@@ -168,6 +169,10 @@ func TestGetTraceInfoTree(t *testing.T) {
 	}
 
 	want := `test-service-1 (01000000000000000000000000000000)      
+├──Root Span                                           
+│  ├──[ Searching... ]                                 
+│  ├──[ Searching... ]                                 
+│  └──[ Searching... ]                                 
 ├──Statistics                                          
 │  └──span count: 4                                    
 └──Resource                                            
@@ -192,5 +197,5 @@ func TestGetTraceInfoTree(t *testing.T) {
 }
 
 func TestGetTraceInfoTreeNoSpans(t *testing.T) {
-	assert.Nil(t, getTraceInfoTree(nil, nil).GetRoot())
+	assert.Nil(t, getTraceInfoTree(context.Background(), nil, nil, nil).GetRoot())
 }


### PR DESCRIPTION
closes: #134 

Add `Root Span` node to details pane. If the root not not found, its child node will be `N/A`

Screenshot:
![image](https://github.com/user-attachments/assets/6f10bbac-749a-4ba5-a56f-8a1000493549)