### PR TITLE
Mark the error spans in traces and timeline page

### DIFF
--- a/tuiexporter/internal/tui/component/page.go
+++ b/tuiexporter/internal/tui/component/page.go
@@ -152,7 +152,7 @@ func (p *TUIPages) createTracePage(store *telemetry.Store) *tview.Flex {
 	table := tview.NewTable().
 		SetBorders(false).
 		SetSelectable(true, false).
-		SetContent(NewSpanDataForTable(store.GetFilteredSvcSpans())).
+		SetContent(NewSpanDataForTable(store.GetTraceCache(), store.GetFilteredSvcSpans())).
 		SetSelectedFunc(func(row, _ int) {
 			p.showTimelineByRow(store, row-1)
 		}).


### PR DESCRIPTION
closes: #137 

Mark the error spans with `[!]` (in table) and `⚠️` (in details) . 

traces:

![image](https://github.com/user-attachments/assets/c5ef355d-8eca-4c4c-892c-5ba3bf7852d5)

timeline:

![image](https://github.com/user-attachments/assets/62d8e9c0-c950-4200-bc33-2fc4239d0542)
