### PR TITLE
Full text modal for attribute tree

### DIFF
--- a/tuiexporter/internal/tui/component/log.go
+++ b/tuiexporter/internal/tui/component/log.go
@@ -81,7 +81,7 @@ func getCellFromLog(log *telemetry.LogData, column int) *tview.TableCell {
 	return tview.NewTableCell(text)
 }
 
-func getLogInfoTree(commands *tview.TextView, l *telemetry.LogData, tcache *telemetry.TraceCache, drawTimelineFn func(traceID string)) *tview.TreeView {
+func getLogInfoTree(commands *tview.TextView, showModalFn showModalFunc, hideModalFn hideModalFunc, l *telemetry.LogData, tcache *telemetry.TraceCache, drawTimelineFn func(traceID string)) *tview.TreeView {
 	if l == nil {
 		return tview.NewTreeView()
 	}
@@ -168,6 +168,8 @@ func getLogInfoTree(commands *tview.TextView, l *telemetry.LogData, tcache *tele
 	tree.SetSelectedFunc(func(node *tview.TreeNode) {
 		node.SetExpanded(!node.IsExpanded())
 	})
+
+	attachModalForTreeAttributes(tree, showModalFn, hideModalFn)
 
 	registerCommandList(commands, tree, nil, KeyMaps{
 		{

--- a/tuiexporter/internal/tui/component/log_test.go
+++ b/tuiexporter/internal/tui/component/log_test.go
@@ -182,7 +182,7 @@ func TestGetLogInfoTree(t *testing.T) {
 	screen.Init()
 	screen.SetSize(sw, sh)
 
-	gottree := getLogInfoTree(nil, logs[0], nil, nil)
+	gottree := getLogInfoTree(nil, noopShowModalFn, noopHideModalFn, logs[0], nil, nil)
 	gottree.SetRect(0, 0, sw, sh)
 	gottree.Draw(screen)
 	screen.Sync()

--- a/tuiexporter/internal/tui/component/metric.go
+++ b/tuiexporter/internal/tui/component/metric.go
@@ -90,7 +90,7 @@ func getCellFromMetrics(metric *telemetry.MetricData, column int) *tview.TableCe
 	return tview.NewTableCell(text)
 }
 
-func getMetricInfoTree(commands *tview.TextView, m *telemetry.MetricData) *tview.TreeView {
+func getMetricInfoTree(commands *tview.TextView, showModalFn showModalFunc, hideModalFn hideModalFunc, m *telemetry.MetricData) *tview.TreeView {
 	if m == nil {
 		return nil
 	}
@@ -370,6 +370,8 @@ func getMetricInfoTree(commands *tview.TextView, m *telemetry.MetricData) *tview
 	tree.SetSelectedFunc(func(node *tview.TreeNode) {
 		node.SetExpanded(!node.IsExpanded())
 	})
+
+	attachModalForTreeAttributes(tree, showModalFn, hideModalFn)
 
 	registerCommandList(commands, tree, nil, KeyMaps{
 		{

--- a/tuiexporter/internal/tui/component/trace.go
+++ b/tuiexporter/internal/tui/component/trace.go
@@ -107,7 +107,7 @@ func getHeaderCell(header []string, column int, sortType *telemetry.SortType) *t
 	return cell
 }
 
-func getTraceInfoTree(commands *tview.TextView, spans []*telemetry.SpanData) *tview.TreeView {
+func getTraceInfoTree(commands *tview.TextView, showModalFn showModalFunc, hideModalFn hideModalFunc, spans []*telemetry.SpanData) *tview.TreeView {
 	if len(spans) == 0 {
 		return tview.NewTreeView()
 	}
@@ -157,9 +157,7 @@ func getTraceInfoTree(commands *tview.TextView, spans []*telemetry.SpanData) *tv
 
 	root.AddChild(resource)
 
-	tree.SetSelectedFunc(func(node *tview.TreeNode) {
-		node.SetExpanded(!node.IsExpanded())
-	})
+	attachModalForTreeAttributes(tree, showModalFn, hideModalFn)
 
 	registerCommandList(commands, tree, nil, KeyMaps{
 		{
@@ -172,7 +170,7 @@ func getTraceInfoTree(commands *tview.TextView, spans []*telemetry.SpanData) *tv
 		},
 		{
 			key:         tcell.NewEventKey(tcell.KeyEnter, ' ', tcell.ModNone),
-			description: "Toggle folding the child nodes",
+			description: "Toggle folding (parent), Show full text (child)",
 		},
 	})
 

--- a/tuiexporter/internal/tui/component/trace_test.go
+++ b/tuiexporter/internal/tui/component/trace_test.go
@@ -7,11 +7,18 @@ import (
 	"time"
 
 	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
 	"github.com/stretchr/testify/assert"
 	"github.com/ymtdzzz/otel-tui/tuiexporter/internal/telemetry"
 	"github.com/ymtdzzz/otel-tui/tuiexporter/internal/test"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )
+
+var noopShowModalFn showModalFunc = func(p tview.Primitive, s string) *tview.TextView {
+	return tview.NewTextView()
+}
+
+var noopHideModalFn hideModalFunc = func(p tview.Primitive) {}
 
 func TestSpanDataForTable(t *testing.T) {
 	// traceid: 1
@@ -232,7 +239,7 @@ func TestGetTraceInfoTree(t *testing.T) {
 	screen.Init()
 	screen.SetSize(sw, sh)
 
-	gottree := getTraceInfoTree(nil, spans)
+	gottree := getTraceInfoTree(nil, noopShowModalFn, noopHideModalFn, spans)
 	gottree.SetRect(0, 0, sw, sh)
 	gottree.Draw(screen)
 	screen.Sync()
@@ -276,5 +283,5 @@ func TestGetTraceInfoTree(t *testing.T) {
 }
 
 func TestGetTraceInfoTreeNoSpans(t *testing.T) {
-	assert.Nil(t, getTraceInfoTree(nil, nil).GetRoot())
+	assert.Nil(t, getTraceInfoTree(nil, noopShowModalFn, noopHideModalFn, nil).GetRoot())
 }

--- a/tuiexporter/internal/tui/component/tree.go
+++ b/tuiexporter/internal/tui/component/tree.go
@@ -1,0 +1,47 @@
+package component
+
+import (
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+type showModalFunc func(tview.Primitive, string) *tview.TextView
+
+type hideModalFunc func(tview.Primitive)
+
+func attachModalForTreeAttributes(tree *tview.TreeView, showFn showModalFunc, hideFn hideModalFunc) {
+	var currentModalNode *tview.TreeNode = nil
+	tree.SetSelectedFunc(func(node *tview.TreeNode) {
+		if len(node.GetChildren()) > 0 {
+			node.SetExpanded(!node.IsExpanded())
+			return
+		}
+		if currentModalNode == node {
+			hideFn(tree)
+			currentModalNode = nil
+			return
+		}
+		textView := showFn(tree, node.GetText())
+		textView.SetTitle("Scroll (Ctrl+J, Ctrl+K)")
+		currentModalNode = node
+		tree.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+			switch event.Key() {
+			case tcell.KeyCtrlJ:
+				row, col := textView.GetScrollOffset()
+				textView.ScrollTo(row+1, col)
+				return nil
+			case tcell.KeyCtrlK:
+				row, col := textView.GetScrollOffset()
+				textView.ScrollTo(row-1, col)
+				return nil
+			}
+			return event
+		})
+	})
+	tree.SetChangedFunc(func(node *tview.TreeNode) {
+		if currentModalNode != nil {
+			hideFn(tree)
+			currentModalNode = nil
+		}
+	})
+}


### PR DESCRIPTION
related: #164 

This PR provides the following feature:

- The modal which shows full text of the selected node
  - Toggle by pressing `Enter` (also, it disappears when the selection changed)
  - Scroll with the key `Ctrl+J`, `Ctrl+K`

![out](https://github.com/user-attachments/assets/bd66f5ab-5499-4e27-8665-febc5b9de1e7)