### PR TITLE
fix: pretty print JSON attribute

### DIFF
--- a/tuiexporter/internal/tui/component/modal.go
+++ b/tuiexporter/internal/tui/component/modal.go
@@ -36,13 +36,13 @@ func attachModalForTreeAttributes(tree *tview.TreeView, showFn showModalFunc, hi
 			return
 		}
 		nodeText := node.GetText()
-		parts := strings.Split(nodeText, ": ")
-		if len(parts) == 2 {
+		parts := strings.SplitN(nodeText, ": ", 2)
+		if len(parts) >= 2 {
 			value := parts[1]
 			if json.Valid([]byte(value)) {
 				value = prettyJSON(value)
-				nodeText = parts[0] + ": " + value
 			}
+			nodeText = parts[0] + ": " + value
 		}
 		textView := showFn(tree, nodeText)
 		textView.SetTitle(MODAL_TITLE)

--- a/tuiexporter/internal/tui/component/modal_test.go
+++ b/tuiexporter/internal/tui/component/modal_test.go
@@ -1,0 +1,112 @@
+package component
+
+import (
+	"testing"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_prettyJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:  "valid JSON object",
+			input: `{"foo":"bar"}`,
+			expected: `{
+  "foo": "bar"
+}`,
+		},
+		{
+			name:     "invalid JSON",
+			input:    `{invalid}`,
+			expected: `{invalid}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := prettyJSON(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func Test_attachModalForTreeAttributes(t *testing.T) {
+	tests := []struct {
+		name          string
+		nodeText      string
+		expectedModal string
+	}{
+		{
+			name:          "simple key-value",
+			nodeText:      "key: value",
+			expectedModal: "key: value",
+		},
+		{
+			name:     "nested JSON object",
+			nodeText: `hoge: {"valid":"value"}`,
+			expectedModal: `hoge: {
+  "valid": "value"
+}`,
+		},
+		{
+			name:     "JSON array",
+			nodeText: `array: ["this","is","array"]`,
+			expectedModal: `array: [
+  "this",
+  "is",
+  "array"
+]`,
+		},
+		{
+			name:          "invalid JSON",
+			nodeText:      "hoge: {invalid}",
+			expectedModal: "hoge: {invalid}",
+		},
+		{
+			name:          "text with colon but not JSON",
+			nodeText:      "time: 12:34:56",
+			expectedModal: "time: 12:34:56",
+		},
+		{
+			name:     "nested JSON with multiple colons",
+			nodeText: `config: {"time":"12:34:56","url":"http://example.com"}`,
+			expectedModal: `config: {
+  "time": "12:34:56",
+  "url": "http://example.com"
+}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// TODO: Add more assertions to check if the modal is shown correctly
+			tree := tview.NewTreeView()
+			root := tview.NewTreeNode("")
+			node := tview.NewTreeNode(tt.nodeText)
+			root.AddChild(node)
+			tree.SetRoot(root)
+
+			var modalText string
+			showFn := func(_ tview.Primitive, text string) *tview.TextView {
+				modalText = text
+				return tview.NewTextView()
+			}
+			hideFn := func(tview.Primitive) {}
+
+			attachModalForTreeAttributes(tree, showFn, hideFn)
+			tree.SetCurrentNode(node)
+
+			event := tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone)
+			handler := tree.InputHandler()
+			handler(event, nil)
+
+			assert.Equal(t, tt.expectedModal, modalText)
+		})
+	}
+}


### PR DESCRIPTION
This PR solves the issue of printing JSON formatted attribute value.
related: #223

![image](https://github.com/user-attachments/assets/3f1ddaba-b5fc-4471-9005-57993c218440)