### PR TITLE
feat: allow telemetries sent from localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Currently, this tool exposes the ports:
 - `4318` to receive OpenTelemetry signals (HTTP)
 - `9411` to receive Zipkin traces (enabled by `--enable-zipkin` option)
 
+The server's Access-Control-Allow-Origin header includes `localhost`, allowing telemetry to be sent directly from browser applications running on localhost.
+
 Options:
 
 ```

--- a/config.yml.tpl
+++ b/config.yml.tpl
@@ -4,6 +4,10 @@ receivers:
     protocols:
       http:
         endpoint: {{ .OTLPHost }}:{{ .OTLPHTTPPort }}
+        cors:
+          allowed_origins:
+            - http://localhost:*
+            - https://localhost:*
       grpc:
         endpoint: {{ .OTLPHost }}:{{ .OTLPGRPCPort }}
 {{- if .EnableZipkin}}
@@ -35,7 +39,7 @@ exporters:
 service:
   pipelines:
     traces:
-      receivers: 
+      receivers:
         - otlp
 {{- if .EnableZipkin}}
         - zipkin

--- a/config_test.go
+++ b/config_test.go
@@ -26,6 +26,10 @@ receivers:
     protocols:
       http:
         endpoint: 0.0.0.0:4318
+        cors:
+          allowed_origins:
+            - http://localhost:*
+            - https://localhost:*
       grpc:
         endpoint: 0.0.0.0:4317
   zipkin:
@@ -50,7 +54,7 @@ exporters:
 service:
   pipelines:
     traces:
-      receivers: 
+      receivers:
         - otlp
         - zipkin
         - otlpjsonfile
@@ -92,6 +96,10 @@ receivers:
     protocols:
       http:
         endpoint: 0.0.0.0:4318
+        cors:
+          allowed_origins:
+            - http://localhost:*
+            - https://localhost:*
       grpc:
         endpoint: 0.0.0.0:4317
 processors:
@@ -101,7 +109,7 @@ exporters:
 service:
   pipelines:
     traces:
-      receivers: 
+      receivers:
         - otlp
       processors:
       exporters:


### PR DESCRIPTION
related: #236 

Allow otel-tui to receive telemetries sent from `localhost`.

## testing

https://opentelemetry.io/docs/languages/js/getting-started/browser/

`document-load.ts`

```ts
import {
  ConsoleSpanExporter,
  SimpleSpanProcessor,
} from '@opentelemetry/sdk-trace-base';
import { WebTracerProvider } from '@opentelemetry/sdk-trace-web';
import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-proto';
import { DocumentLoadInstrumentation } from '@opentelemetry/instrumentation-document-load';
import { ZoneContextManager } from '@opentelemetry/context-zone';
import { registerInstrumentations } from '@opentelemetry/instrumentation';

const exporter = new OTLPTraceExporter({
  // optional - default url is http://localhost:4318/v1/traces
  url: 'http://localhost:4318/v1/traces',
  // optional - collection of custom headers to be sent with each request, empty by default
  headers: {},
});

const provider = new WebTracerProvider({
  spanProcessors: [
    new SimpleSpanProcessor(exporter),
    new SimpleSpanProcessor(new ConsoleSpanExporter()),
  ],
});

provider.register({
  // Changing default contextManager to use ZoneContextManager - supports asynchronous operations - optional
  contextManager: new ZoneContextManager(),
});

// Registering instrumentations
registerInstrumentations({
  instrumentations: [new DocumentLoadInstrumentation()],
});
```

![image](https://github.com/user-attachments/assets/ea6969e8-9ec7-4566-a6c4-ae5ade8beb61)

![image](https://github.com/user-attachments/assets/90113e70-4eee-4abb-9c9b-1a1bac54fa13)