### PR TITLE
fix: use ISO-ish format, add ms and TZ to log timestamps

### DIFF
--- a/tuiexporter/internal/telemetry/store.go
+++ b/tuiexporter/internal/telemetry/store.go
@@ -130,7 +130,7 @@ func (l *LogData) GetServiceName() string {
 }
 
 func (l *LogData) GetTimestampText() string {
-	return l.Log.Timestamp().AsTime().Format("2006/01/02 15:04:05")
+	return l.Log.Timestamp().AsTime().Format("2006-01-02 15:04:05.000Z")
 }
 
 func (l *LogData) GetSeverity() string {

--- a/tuiexporter/internal/tui/component/log.go
+++ b/tuiexporter/internal/tui/component/log.go
@@ -199,10 +199,10 @@ func getLogInfoTree(commands *tview.TextView, showModalFn showModalFunc, hideMod
 	spanNode := tview.NewTreeNode(fmt.Sprintf("span id: %s", spanID))
 	record.AddChild(spanNode)
 
-	timestamp := l.Log.Timestamp().AsTime().Format("2006/01/02 15:04:05.000000")
+	timestamp := l.Log.Timestamp().AsTime().Format("2006-01-02 15:04:05.000000Z07")
 	record.AddChild(tview.NewTreeNode(fmt.Sprintf("timestamp: %s", timestamp)))
 
-	otimestamp := l.Log.ObservedTimestamp().AsTime().Format("2006/01/02 15:04:05.000000")
+	otimestamp := l.Log.ObservedTimestamp().AsTime().Format("2006-01-02 15:04:05.000000Z07")
 	record.AddChild(tview.NewTreeNode(fmt.Sprintf("observed timestamp: %s", otimestamp)))
 
 	body := tview.NewTreeNode(fmt.Sprintf("body: %s", l.Log.Body().AsString()))

--- a/tuiexporter/internal/tui/component/log_test.go
+++ b/tuiexporter/internal/tui/component/log_test.go
@@ -145,7 +145,7 @@ func TestLogDataForTable(t *testing.T) {
 					name:   "timestamp trace 1 span-2-1-1",
 					row:    6,
 					column: 2,
-					want:   "2022/10/21 07:10:02",
+					want:   "2022-10-21 07:10:02.100Z",
 				},
 				{
 					name:   "serverity trace 1 span-2-1-1",
@@ -229,7 +229,7 @@ func TestLogDataForTable(t *testing.T) {
 					name:   "timestamp trace 1 span-2-1-1",
 					row:    6,
 					column: 1,
-					want:   "2022/10/21 07:10:02",
+					want:   "2022-10-21 07:10:02.100Z",
 				},
 				{
 					name:   "serverity trace 1 span-2-1-1",
@@ -326,8 +326,8 @@ func TestGetLogInfoTree(t *testing.T) {
    └──LogRecord
       ├──trace id: 01000000000000000000000000000000
       ├──span id: 0100000000000000
-      ├──timestamp: 2022/10/21 07:10:02.100000
-      ├──observed timestamp: 2022/10/21 07:10:02.200000
+      ├──timestamp: 2022-10-21 07:10:02.100000Z
+      ├──observed timestamp: 2022-10-21 07:10:02.200000
       ├──body: log body 0-0-0-0
       ├──severity: INFO (9)
       ├──flags: 0


### PR DESCRIPTION
Uses `ms` precision in the list of logs, also uses an ISO3601-ish format (probably should use a consistent format everywhere?)