### PR TITLE
fix(metrics): panic when bucket count length is 1

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -3,6 +3,7 @@ cel.dev/expr v0.16.0/go.mod h1:TRSuuV7DlVCE/uwv5QbAiW/v8l5O8C4eEPHeu7gf7Sg=
 cel.dev/expr v0.16.2/go.mod h1:gXngZQMkWJoSbE8mOzehJlXQyubn/Vg0vR9/F3W7iw8=
 cel.dev/expr v0.19.0/go.mod h1:MrpN08Q+lEBs+bGYdLxxHkZoUSsCp0nSKTs0nTymJgw=
 cel.dev/expr v0.19.1/go.mod h1:MrpN08Q+lEBs+bGYdLxxHkZoUSsCp0nSKTs0nTymJgw=
+cel.dev/expr v0.20.0/go.mod h1:MrpN08Q+lEBs+bGYdLxxHkZoUSsCp0nSKTs0nTymJgw=
 cloud.google.com/go v0.44.3/go.mod h1:60680Gw3Yr4ikxnPRS/oxxkBccT6SA1yMk63TGekxKY=
 cloud.google.com/go v0.72.0/go.mod h1:M+5Vjvlc2wnp6tjzE102Dw08nGShTscUx2nZMufOKPI=
 cloud.google.com/go v0.74.0/go.mod h1:VV1xSbzvo+9QJOxLDaJfTjx5e+MePCpCWwvftOeQmWk=
@@ -376,6 +377,7 @@ codeberg.org/go-fonts/liberation v0.5.0/go.mod h1:zS/2e1354/mJ4pGzIIaEtm/59VFCFn
 codeberg.org/go-latex/latex v0.1.0/go.mod h1:LA0q/AyWIYrqVd+A9Upkgsb+IqPcmSTKc9Dny04MHMw=
 codeberg.org/go-pdf/fpdf v0.10.0/go.mod h1:Y0DGRAdZ0OmnZPvjbMp/1bYxmIPxm0ws4tfoPOc4LjU=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
+dario.cat/mergo v1.0.1/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20221208032759-85de2813cf6b/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 git.sr.ht/~sbinet/gg v0.5.0/go.mod h1:G2C0eRESqlKhS7ErsNey6HHrqU1PwsnCQlekFi9Q2Oo=
 git.sr.ht/~sbinet/gg v0.6.0/go.mod h1:uucygbfC9wVPQIfrmwM2et0imr8L7KQWywX0xpFMm94=
@@ -383,6 +385,7 @@ github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24/go.mod h
 github.com/GoogleCloudPlatform/grpc-gcp-go/grpcgcp v1.5.0/go.mod h1:dppbR7CwXD4pgtV9t3wD1812RaLDcBjtblcDF5f1vI0=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.24.2/go.mod h1:itPGVDKf9cC/ov4MdvJ2QZ0khw4bfoo9jzwTJlaxy2k=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.25.0/go.mod h1:obipzmGjfSjam60XLwGfqUkJsfiheAl+TUjG+4yzyPM=
+github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.26.0/go.mod h1:2bIszWvQRlJVmJLiuLhukLImRjKPcYdzzsx6darK02A=
 github.com/HdrHistogram/hdrhistogram-go v1.1.2/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
 github.com/IBM/sarama v1.43.1/go.mod h1:GG5q1RURtDNPz8xxJs3mgX6Ytak8Z9eLhAkJPObe2xE=
 github.com/IBM/sarama v1.43.2/go.mod h1:Kyo4WkF24Z+1nz7xeVUFWIuKVV8RS3wM8mkvPKMdXFQ=
@@ -501,6 +504,7 @@ github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm
 github.com/gin-gonic/gin v1.10.0/go.mod h1:4PMNQiOhvDRa013RKVbsiNwoyezlm2rm0uX/T7kzp5Y=
 github.com/go-fonts/liberation v0.3.2/go.mod h1:N0QsDLVUQPy3UYg9XAc3Uh3UDMp2Z7M1o4+X98dXkmI=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20231223183121-56fa3ac82ce7/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
+github.com/go-jose/go-jose/v4 v4.0.4/go.mod h1:NKb5HO1EZccyMpiZNbdUw/14tiXNyUJh188dfnMCAfc=
 github.com/go-kit/kit v0.12.0/go.mod h1:lHd+EkCZPIwYItmGDDRdhinkzX2A1sj+M9biaEaizzs=
 github.com/go-latex/latex v0.0.0-20231108140139-5c1ce85aa4ea/go.mod h1:Y7Vld91/HRbTBm7JwoI7HejdDB0u+e9AUBO9MB7yuZk=
 github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
@@ -606,6 +610,7 @@ github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2
 github.com/lyft/protoc-gen-star/v2 v2.0.3/go.mod h1:amey7yeodaJhXSbf/TlLvWiqQfLOSpEk//mLlc+axEk=
 github.com/lyft/protoc-gen-star/v2 v2.0.4-0.20230330145011-496ad1ac90a4/go.mod h1:amey7yeodaJhXSbf/TlLvWiqQfLOSpEk//mLlc+axEk=
 github.com/magiconair/properties v1.8.7/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
+github.com/magiconair/properties v1.8.9/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
 github.com/markbates/pkger v0.17.0/go.mod h1:0JoVlrol20BSywW79rN3kdFFsE5xYM+rSCQDXbLhiuI=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
@@ -685,6 +690,7 @@ github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.119.0/go
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.120.1/go.mod h1:K7zaoqIAYuJatrZL2tn2kewv8Gj04zDA/OHNOGSPSuY=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.121.0/go.mod h1:MoCMz/TtwE0yYmOL3uJ+VoOxZpt7+obfdLrKNG40deI=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.123.0/go.mod h1:EAzpBsYIXoXQbyVTkvfOksaiq+jctnoxnPevB+/xsqw=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.125.0/go.mod h1:xxQBETnfDs2DRPVXgg8aeeVKPFzICjp3wce1858hJeo=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/kafka/topic v0.111.0/go.mod h1:Lqc5Me0HU2a/DAESI//0UuKnGszTwuDnV+oVOLRkfio=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/kafka/topic v0.115.0/go.mod h1:1q/L2R/28emNCz0EHfxEw853I6lPxTcHTqS+UrMea0k=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/kafka/topic v0.116.0/go.mod h1:1q/L2R/28emNCz0EHfxEw853I6lPxTcHTqS+UrMea0k=
@@ -704,6 +710,7 @@ github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.119.0
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.120.1/go.mod h1:dOyaUjylOncqwxHyRNK9LQeMwpj5SwDGOGdCyiTXjjY=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.121.0/go.mod h1:9ghLP9djsDo5xzmzkADqeJjZb3l92XIRhpAz/ToX2QM=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.123.0/go.mod h1:yv3tSTQdVXHvNT+OZ95Drnwb5ntWdlhTthKAi/sB5QY=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.125.0/go.mod h1:/WDZg8/Uk2niDeFWkijYvWkQ9gaRF0Vkj/RxGDRcMEY=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.106.1/go.mod h1:ehzaiDdkrww7l1Stvse5GCOAsAZOpFcgeIbB/2PqFs4=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.107.0/go.mod h1:/RtBag3LuHIkqN4bo8Erd3jCzA3gea70l9WyJ9TncXM=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.110.0 h1:KYBzbgQyCz4i5zjzs0iBOFuNh2vagaw2seqvZ7Lftxk=
@@ -794,6 +801,7 @@ github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFo
 github.com/ryanuber/columnize v2.1.2+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shirou/gopsutil/v3 v3.24.5/go.mod h1:bsoOS1aStSs9ErQ1WWfxllSeS1K5D+U30r2NfcubMVk=
 github.com/shoenig/go-m1cpu v0.1.6/go.mod h1:1JJMcUBvfNwpq05QDQVAnx3gUHr9IYF7GNg9SUEw2VQ=
@@ -810,12 +818,14 @@ github.com/spf13/cobra v1.6.1/go.mod h1:IOw/AERYS7UzyrGinqmz6HLUo219MORXGxhbaJUq
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.19.0/go.mod h1:GQUN9bilAbhU/jgc1bKs99f/suXKeUMct8Adx5+Ntkg=
+github.com/spiffe/go-spiffe/v2 v2.5.0/go.mod h1:P+NxobPc6wXhVtINNtFjNWGBTreew1GBUCwT2wPmb7g=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/testcontainers/testcontainers-go v0.31.0/go.mod h1:D2lAoA0zUFiSY+eAflqK5mcUx/A5hrrORaEQrd0SefI=
 github.com/testcontainers/testcontainers-go v0.34.0/go.mod h1:6P/kMkQe8yqPHfPWNulFGdFHTD8HB2vLq/231xY2iPQ=
 github.com/testcontainers/testcontainers-go v0.35.0/go.mod h1:oEVBj5zrfJTrgjwONs1SsRbnBtH9OKl+IGl3UMcr2B4=
+github.com/testcontainers/testcontainers-go v0.36.0/go.mod h1:yk73GVJ0KUZIHUtFna6MO7QS144qYpoY8lEEtU9Hed0=
 github.com/tilinna/clock v1.1.0/go.mod h1:ZsP7BcY7sEEz7ktc0IVy8Us6boDrK8VradlKRUGfOao=
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ua-parser/uap-go v0.0.0-20240611065828-3a4781585db6/go.mod h1:BUbeWZiieNxAuuADTBNb3/aeje6on3DhU3rpWsQSB1E=
@@ -834,6 +844,7 @@ github.com/xlab/treeprint v1.2.0/go.mod h1:gj5Gd3gPdKtR1ikdDK6fnFLdmIS0X30kTTuNd
 github.com/ymtdzzz/mermaid-ascii v0.0.0-20250116141729-eafe4748a419 h1:oVe1YcVRyoRGNeAjkost3Z3il83lCQaNwxwGGAw0L8g=
 github.com/ymtdzzz/mermaid-ascii v0.0.0-20250116141729-eafe4748a419/go.mod h1:gDx5dss6A/czppfsA5jQ0J5jxYpfhojLVgiF5ArbIE8=
 github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d/go.mod h1:rHwXgn7JulP+udvsHwJoVG1YGAP6VLg4y9I5dyZdqmA=
+github.com/zeebo/errs v1.4.0/go.mod h1:sgbWHsvVuTPHcqJJGQ1WhI5KbWlHYz+2+2C/LSEtCw4=
 github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
 go.einride.tech/aip v0.67.1/go.mod h1:ZGX4/zKw8dcgzdLsrvpOOGxfxI2QSk12SlP7d6c0/XI=
 go.elastic.co/go-licence-detector v0.6.1/go.mod h1:qQ1clBRS2f0Ee5ie+y2LLYnyhSNJNm0Ha6d7SoYVtM4=

--- a/tuiexporter/internal/telemetry/store_test.go
+++ b/tuiexporter/internal/telemetry/store_test.go
@@ -143,7 +143,7 @@ func TestStoreMetricFilters(t *testing.T) {
 	//      └- metric: metric-2-1-1
 	//        └- datapoint: dp-2-1-1-1
 	store := NewStore()
-	payload, testdata := test.GenerateOTLPMetricsPayload(t, 2, []int{2, 1}, [][]int{{2, 1}, {1}})
+	payload, testdata := test.GenerateOTLPGaugeMetricsPayload(t, 2, []int{2, 1}, [][]int{{2, 1}, {1}})
 	store.AddMetric(&payload)
 
 	store.ApplyFilterMetrics("service-2")
@@ -510,7 +510,7 @@ func TestStoreAddMetricWithoutRotation(t *testing.T) {
 	store := NewStore()
 	store.maxMetricCount = 3 // no rotation
 	before := store.updatedAt
-	payload, testdata := test.GenerateOTLPMetricsPayload(t, 2, []int{2, 1}, [][]int{{2, 1}, {1}})
+	payload, testdata := test.GenerateOTLPGaugeMetricsPayload(t, 2, []int{2, 1}, [][]int{{2, 1}, {1}})
 	store.AddMetric(&payload)
 
 	assert.Equal(t, "", store.filterMetric)
@@ -554,7 +554,7 @@ func TestStoreAddMetricWithRotation(t *testing.T) {
 	store := NewStore()
 	store.maxMetricCount = 1 // no rotation
 	before := store.updatedAt
-	payload, testdata := test.GenerateOTLPMetricsPayload(t, 2, []int{2, 1}, [][]int{{2, 1}, {1}})
+	payload, testdata := test.GenerateOTLPGaugeMetricsPayload(t, 2, []int{2, 1}, [][]int{{2, 1}, {1}})
 	store.AddMetric(&payload)
 
 	assert.Equal(t, "", store.filterMetric)
@@ -718,7 +718,7 @@ func TestStoreFlush(t *testing.T) {
 	tp2, _ := test.GenerateOTLPTracesPayload(t, 2, 1, []int{1}, [][]int{{1}})
 	lp1, _ := test.GenerateOTLPLogsPayload(t, 1, 2, []int{2, 1}, [][]int{{2, 1}, {1}})
 	lp2, _ := test.GenerateOTLPLogsPayload(t, 2, 1, []int{1}, [][]int{{1}})
-	m, _ := test.GenerateOTLPMetricsPayload(t, 2, []int{2, 1}, [][]int{{2, 1}, {1}})
+	m, _ := test.GenerateOTLPGaugeMetricsPayload(t, 2, []int{2, 1}, [][]int{{2, 1}, {1}})
 	store.AddSpan(&tp1)
 	store.AddSpan(&tp2)
 	store.AddLog(&lp1)

--- a/tuiexporter/internal/test/metricgen.go
+++ b/tuiexporter/internal/test/metricgen.go
@@ -13,7 +13,7 @@ type GeneratedMetrics struct {
 	SMetrics []*pmetric.ScopeMetrics
 }
 
-func GenerateOTLPMetricsPayload(t *testing.T, resourceCount int, scopeCount []int, dpCount [][]int) (pmetric.Metrics, *GeneratedMetrics) {
+func GenerateOTLPGaugeMetricsPayload(t *testing.T, resourceCount int, scopeCount []int, dpCount [][]int) (pmetric.Metrics, *GeneratedMetrics) {
 	t.Helper()
 
 	generatedMetrics := &GeneratedMetrics{
@@ -43,12 +43,54 @@ func GenerateOTLPMetricsPayload(t *testing.T, resourceCount int, scopeCount []in
 			scopeMetric.Metrics().EnsureCapacity(1)
 			metric := scopeMetric.Metrics().AppendEmpty()
 			fillMetric(t, metric, resourceIndex, scopeIndex)
-			// TODO: other metric types and value types?
 			gauge := metric.SetEmptyGauge()
 			gauge.DataPoints().EnsureCapacity(dpCount[resourceIndex][scopeIndex])
 			for dpIndex := 0; dpIndex < dpCount[resourceIndex][scopeIndex]; dpIndex++ {
 				dp := metric.Gauge().DataPoints().AppendEmpty()
-				fillDataPoint(t, dp, dpIndex)
+				fillNumberDataPoint(t, dp, dpIndex)
+			}
+			generatedMetrics.Metrics = append(generatedMetrics.Metrics, &metric)
+		}
+	}
+
+	return metricData, generatedMetrics
+}
+
+func GenerateOTLPHistogramMetricsPayload(t *testing.T, resourceCount int, scopeCount []int, dpCount [][]int) (pmetric.Metrics, *GeneratedMetrics) {
+	t.Helper()
+
+	generatedMetrics := &GeneratedMetrics{
+		Metrics:  []*pmetric.Metric{},
+		RMetrics: []*pmetric.ResourceMetrics{},
+		SMetrics: []*pmetric.ScopeMetrics{},
+	}
+	metricData := pmetric.NewMetrics()
+
+	// Create and populate resource data
+	metricData.ResourceMetrics().EnsureCapacity(resourceCount)
+	for resourceIndex := 0; resourceIndex < resourceCount; resourceIndex++ {
+		scopeCount := scopeCount[resourceIndex]
+		resourceMetric := metricData.ResourceMetrics().AppendEmpty()
+		fillResource(t, resourceMetric.Resource(), resourceIndex)
+		generatedMetrics.RMetrics = append(generatedMetrics.RMetrics, &resourceMetric)
+
+		// Create and populate instrumentation scope data
+		resourceMetric.ScopeMetrics().EnsureCapacity(scopeCount)
+		for scopeIndex := 0; scopeIndex < scopeCount; scopeIndex++ {
+			scopeMetric := resourceMetric.ScopeMetrics().AppendEmpty()
+			fillScope(t, scopeMetric.Scope(), resourceIndex, scopeIndex)
+			generatedMetrics.SMetrics = append(generatedMetrics.SMetrics, &scopeMetric)
+
+			// Create and populate metrics
+			// 1 metric per scope
+			scopeMetric.Metrics().EnsureCapacity(1)
+			metric := scopeMetric.Metrics().AppendEmpty()
+			fillMetric(t, metric, resourceIndex, scopeIndex)
+			histogram := metric.SetEmptyHistogram()
+			histogram.DataPoints().EnsureCapacity(dpCount[resourceIndex][scopeIndex])
+			for dpIndex := 0; dpIndex < dpCount[resourceIndex][scopeIndex]; dpIndex++ {
+				dp := metric.Histogram().DataPoints().AppendEmpty()
+				fillHistogramDataPoint(t, dp, dpIndex)
 			}
 			generatedMetrics.Metrics = append(generatedMetrics.Metrics, &metric)
 		}
@@ -65,10 +107,26 @@ func fillMetric(t *testing.T, m pmetric.Metric, resourceIndex, scopeIndex int) {
 	m.SetDescription("test description")
 }
 
-func fillDataPoint(t *testing.T, dp pmetric.NumberDataPoint, dpIndex int) {
+func fillNumberDataPoint(t *testing.T, dp pmetric.NumberDataPoint, dpIndex int) {
 	t.Helper()
 
 	dp.SetDoubleValue(float64(dpIndex + 1))
+	dp.SetFlags(pmetric.DefaultDataPointFlags.WithNoRecordedValue(false))
+	// TODO: examplers
+	dp.Attributes().PutInt("dp index", int64(dpIndex))
+}
+
+func fillHistogramDataPoint(t *testing.T, dp pmetric.HistogramDataPoint, dpIndex int) {
+	t.Helper()
+
+	if dpIndex < 0 {
+		dp.SetCount(0)
+	} else {
+		dp.SetCount(uint64(dpIndex + 1)) // #nosec G115
+	}
+	dp.SetSum(float64(dpIndex + 1))
+	dp.BucketCounts().FromRaw([]uint64{0, 10, 20, 5, 0})
+	dp.ExplicitBounds().FromRaw([]float64{0, 10, 20, 30})
 	dp.SetFlags(pmetric.DefaultDataPointFlags.WithNoRecordedValue(false))
 	// TODO: examplers
 	dp.Attributes().PutInt("dp index", int64(dpIndex))

--- a/tuiexporter/internal/tui/component/metric.go
+++ b/tuiexporter/internal/tui/component/metric.go
@@ -431,17 +431,28 @@ func drawMetricHistogramChart(commands *tview.TextView, m *telemetry.MetricData)
 		txt := tview.NewFlex().SetDirection(tview.FlexRow)
 		txt.SetBorder(true).SetTitle("Attributes")
 		for bci := 0; bci < dp.BucketCounts().Len(); bci++ {
-			if bci == dp.BucketCounts().Len()-1 {
-				ch.AddBar(fmt.Sprintf("%.1f~", dp.ExplicitBounds().At(bci-1)), uint64ToInt(dp.BucketCounts().At(bci)), tcell.ColorYellow)
+			var label string
+
+			if dp.ExplicitBounds().Len() == 0 {
+				label = "inf"
 			} else {
-				ch.AddBar(fmt.Sprintf("%.1f", dp.ExplicitBounds().At(bci)), uint64ToInt(dp.BucketCounts().At(bci)), tcell.ColorYellow)
+				switch {
+				case bci == 0:
+					label = fmt.Sprintf("~%.1f", dp.ExplicitBounds().At(0))
+				case bci == dp.BucketCounts().Len()-1:
+					label = fmt.Sprintf("%.1f~", dp.ExplicitBounds().At(bci-1))
+				default:
+					label = fmt.Sprintf("%.1f", dp.ExplicitBounds().At(bci))
+				}
 			}
+
+			ch.AddBar(label, uint64ToInt(dp.BucketCounts().At(bci)), tcell.ColorYellow)
 		}
 		sts.AddItem(tview.NewTextView().SetText(fmt.Sprintf("● max: %.1f", dp.Max())), 1, 1, false)
 		sts.AddItem(tview.NewTextView().SetText(fmt.Sprintf("● min: %.1f", dp.Min())), 1, 1, false)
 		sts.AddItem(tview.NewTextView().SetText(fmt.Sprintf("● sum: %.1f", dp.Sum())), 1, 1, false)
 		dp.Attributes().Range(func(k string, v pcommon.Value) bool {
-			txt.AddItem(tview.NewTextView().SetText(fmt.Sprintf("● %s: %s", k, v.Str())), 2, 1, false)
+			txt.AddItem(tview.NewTextView().SetText(fmt.Sprintf("● %s: %s", k, v.AsString())), 2, 1, false)
 			return true
 		})
 		side.AddItem(sts, 5, 1, false).AddItem(txt, 0, 1, false)

--- a/tuiexporter/internal/tui/component/metric_test.go
+++ b/tuiexporter/internal/tui/component/metric_test.go
@@ -1,0 +1,136 @@
+package component
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+	"github.com/stretchr/testify/assert"
+	"github.com/ymtdzzz/otel-tui/tuiexporter/internal/telemetry"
+	"github.com/ymtdzzz/otel-tui/tuiexporter/internal/test"
+)
+
+func TestDrawMetricHistogramChart(t *testing.T) {
+	tests := []struct {
+		name         string
+		metricDataFn func() *telemetry.MetricData
+		want         string
+	}{
+		{
+			name: "with bounds",
+			metricDataFn: func() *telemetry.MetricData {
+				_, m := test.GenerateOTLPHistogramMetricsPayload(t, 1, []int{1}, [][]int{{1}})
+
+				return &telemetry.MetricData{
+					Metric: m.Metrics[0],
+				}
+			},
+			want: `┌───────────────────Data point [1 / 1] ( <- | -> )───────────────────┐┌─────────Statistics─────────┐
+│                                                                    ││● max: 0.0                  │
+│ 20┆             20                                                 ││● min: 0.0                  │
+│   ┆             ███                                                ││● sum: 1.0                  │
+│   ┆             ███                                                │└────────────────────────────┘
+│   ┆             ███                                                │┌─────────Attributes─────────┐
+│   ┆             ███                                                ││● dp index: 0               │
+│   ┆             ███                                                ││                            │
+│   ┆             ███                                                ││                            │
+│   ┆       10    ███                                                ││                            │
+│   ┆       ███   ███                                                ││                            │
+│   ┆       ███   ███                                                ││                            │
+│   ┆       ███   ███                                                ││                            │
+│   ┆       ███   ███   5                                            ││                            │
+│   ┆       ███   ███   ███                                          ││                            │
+│   ┆       ███   ███   ███                                          ││                            │
+│   ┆ 0     ███   ███   ███   0                                      ││                            │
+│  0└┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄ ││                            │
+│     ~0.0  10.0  20.0  30.0  30.0~                                  ││                            │
+└────────────────────────────────────────────────────────────────────┘└────────────────────────────┘
+			`,
+		},
+		{
+			name: "without bounds",
+			metricDataFn: func() *telemetry.MetricData {
+				_, m := test.GenerateOTLPHistogramMetricsPayload(t, 1, []int{1}, [][]int{{1}})
+				m.Metrics[0].Histogram().DataPoints().At(0).BucketCounts().FromRaw([]uint64{10})
+				m.Metrics[0].Histogram().DataPoints().At(0).ExplicitBounds().FromRaw([]float64{})
+
+				return &telemetry.MetricData{
+					Metric: m.Metrics[0],
+				}
+			},
+			want: `┌───────────────────Data point [1 / 1] ( <- | -> )───────────────────┐┌─────────Statistics─────────┐
+│                                                                    ││● max: 0.0                  │
+│ 10┆ 10                                                             ││● min: 0.0                  │
+│   ┆ ███                                                            ││● sum: 1.0                  │
+│   ┆ ███                                                            │└────────────────────────────┘
+│   ┆ ███                                                            │┌─────────Attributes─────────┐
+│   ┆ ███                                                            ││● dp index: 0               │
+│   ┆ ███                                                            ││                            │
+│   ┆ ███                                                            ││                            │
+│   ┆ ███                                                            ││                            │
+│   ┆ ███                                                            ││                            │
+│   ┆ ███                                                            ││                            │
+│   ┆ ███                                                            ││                            │
+│   ┆ ███                                                            ││                            │
+│   ┆ ███                                                            ││                            │
+│   ┆ ███                                                            ││                            │
+│   ┆ ███                                                            ││                            │
+│  0└┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄ ││                            │
+│     inf                                                            ││                            │
+└────────────────────────────────────────────────────────────────────┘└────────────────────────────┘
+					`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			commands := tview.NewTextView()
+
+			chart := drawMetricHistogramChart(commands, tt.metricDataFn())
+
+			assert.NotNil(t, chart)
+
+			_, ok := chart.(*tview.Flex)
+			assert.True(t, ok)
+
+			screen := tcell.NewSimulationScreen("")
+			err := screen.Init()
+			assert.NoError(t, err)
+
+			w, h := 100, 20
+			screen.SetSize(w, h)
+
+			chart.SetRect(0, 0, w, h)
+			chart.Draw(screen)
+			screen.Sync()
+
+			contents, w, _ := screen.GetContents()
+			var got bytes.Buffer
+			for n, v := range contents {
+				var err error
+				if n%w == w-1 {
+					_, err = fmt.Fprintf(&got, "%c\n", v.Runes[0])
+				} else {
+					_, err = fmt.Fprintf(&got, "%c", v.Runes[0])
+				}
+				if err != nil {
+					t.Error(err)
+				}
+			}
+
+			t.Log(got.String())
+
+			gotLines := strings.Split(got.String(), "\n")
+			wantLines := strings.Split(tt.want, "\n")
+
+			assert.Equal(t, len(wantLines), len(gotLines))
+
+			for i := 0; i < len(wantLines); i++ {
+				assert.Equal(t, strings.TrimRight(wantLines[i], " \t\r"), strings.TrimRight(gotLines[i], " \t\r"))
+			}
+		})
+	}
+}


### PR DESCRIPTION
related: #274

This PR fixes a panic that occurred when processing histogram datapoints with only one bucket (i.e., no explicit bounds).  
It adds a conditional branch to safely handle the case where `ExplicitBounds.Len() == 0`.