### PR TITLE
feat(metric): remove --enable-prom flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,12 @@ Usage:
   otel-tui [flags]
 
 Flags:
-      --enable-prom               Enable the prometheus receiver
       --enable-zipkin             Enable the zipkin receiver
       --grpc int                  The port number on which we listen for OTLP grpc payloads (default 4317)
   -h, --help                      help for otel-tui
       --host string               The host where we expose our OTLP endpoints (default "0.0.0.0")
       --http int                  The port number on which we listen for OTLP http payloads (default 4318)
-      --prom-target stringArray   The target endpoints for the prometheus receiver (--prom-target "localhost:9000" --prom-target "http://other-host:9000/custom/prometheus")
+      --prom-target stringArray   Enable the prometheus receiver and specify the target endpoints for the receiver (--prom-target "localhost:9000" --prom-target "http://other-host:9000/custom/prometheus")
   -v, --version                   version for otel-tui
 ```
 

--- a/config.go
+++ b/config.go
@@ -26,7 +26,6 @@ type Config struct {
 	OTLPHTTPPort      int
 	OTLPGRPCPort      int
 	EnableZipkin      bool
-	EnableProm        bool
 	FromJSONFile      string
 	PromTarget        []string
 	PromScrapeConfigs []*PromScrapeConfig
@@ -37,7 +36,6 @@ func NewConfig(
 	otlpHTTPPort int,
 	otlpGRPCPort int,
 	enableZipkin bool,
-	enableProm bool,
 	fromJSONFile string,
 	promTarget []string,
 ) (*Config, error) {
@@ -46,7 +44,6 @@ func NewConfig(
 		OTLPHTTPPort: otlpHTTPPort,
 		OTLPGRPCPort: otlpGRPCPort,
 		EnableZipkin: enableZipkin,
-		EnableProm:   enableProm,
 		FromJSONFile: fromJSONFile,
 		PromTarget:   promTarget,
 	}
@@ -55,10 +52,8 @@ func NewConfig(
 		return nil, err
 	}
 
-	if enableProm {
-		if err := cfg.buildPromScrapeConfigs(); err != nil {
-			return nil, fmt.Errorf("failed to build Prometheus scrape configs: %w", err)
-		}
+	if err := cfg.buildPromScrapeConfigs(); err != nil {
+		return nil, fmt.Errorf("failed to build Prometheus scrape configs: %w", err)
 	}
 
 	return cfg, nil
@@ -136,9 +131,6 @@ func structToMap(s any) (map[string]any, error) {
 
 // validate checks if the otel-tui configuration is valid
 func (cfg *Config) validate() error {
-	if cfg.EnableProm && len(cfg.PromTarget) == 0 {
-		return errors.New("the target endpoints for the prometheus receiver (--prom-target) must be specified when prometheus receiver enabled")
-	}
 	if _, err := os.Stat(cfg.FromJSONFile); len(cfg.FromJSONFile) > 0 && err != nil {
 		return errors.New("the initial data JSON file does not exist")
 	}

--- a/config.yml.tpl
+++ b/config.yml.tpl
@@ -14,7 +14,7 @@ receivers:
   zipkin:
     endpoint: 0.0.0.0:9411
 {{- end}}
-{{- if and (.EnableProm) (gt (len .PromScrapeConfigs) 0)}}
+{{- if gt (len .PromScrapeConfigs) 0}}
   prometheus:
     config:
       scrape_configs:
@@ -68,7 +68,7 @@ service:
     metrics:
       receivers:
         - otlp
-{{- if .EnableProm}}
+{{- if gt (len .PromScrapeConfigs) 0}}
         - prometheus
 {{- end}}
 {{- if gt (len .FromJSONFile) 0}}

--- a/config_test.go
+++ b/config_test.go
@@ -69,7 +69,6 @@ func TestConfigRenderYml(t *testing.T) {
 		OTLPHTTPPort: 4318,
 		OTLPGRPCPort: 4317,
 		EnableZipkin: true,
-		EnableProm:   true,
 		FromJSONFile: "./path/to/init.json",
 		PromTarget: []string{
 			"localhost:9090",
@@ -159,7 +158,6 @@ func TestConfigRenderYmlMinimum(t *testing.T) {
 		OTLPHTTPPort: 4318,
 		OTLPGRPCPort: 4317,
 		EnableZipkin: false,
-		EnableProm:   false,
 	}
 	want := `yaml:
 receivers:
@@ -198,6 +196,8 @@ service:
       exporters:
         - tui
 `
+	err := cfg.buildPromScrapeConfigs()
+	assert.Nil(t, err)
 	got, err := cfg.RenderYml()
 	assert.Nil(t, err)
 	assert.Equal(t, want, got)
@@ -221,7 +221,6 @@ func TestValidate(t *testing.T) {
 				OTLPHTTPPort: 4318,
 				OTLPGRPCPort: 4317,
 				EnableZipkin: true,
-				EnableProm:   true,
 				FromJSONFile: "./main.go",
 				PromTarget: []string{
 					"localhost:9000",
@@ -229,16 +228,6 @@ func TestValidate(t *testing.T) {
 				},
 			},
 			want: nil,
-		},
-		{
-			name: "NG_Prom",
-			cfg: &Config{
-				OTLPHost:     "0.0.0.0",
-				OTLPHTTPPort: 4318,
-				OTLPGRPCPort: 4317,
-				EnableProm:   true,
-			},
-			want: errors.New("the target endpoints for the prometheus receiver (--prom-target) must be specified when prometheus receiver enabled"),
 		},
 		{
 			name: "NG_JSON_File",

--- a/main.go
+++ b/main.go
@@ -45,7 +45,6 @@ func newCommand(params otelcol.CollectorSettings) *cobra.Command {
 		httpPortFlag, grpcPortFlag int
 		hostFlag                   string
 		zipkinEnabledFlag          bool
-		promEnabledFlag            bool
 		promTargetFlag             []string
 		fromJSONFileFlag           string
 	)
@@ -56,17 +55,11 @@ func newCommand(params otelcol.CollectorSettings) *cobra.Command {
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 
-			// if a prom target is provided, enable the prom receiver anyway
-			if len(promTargetFlag) > 0 {
-				promEnabledFlag = true
-			}
-
 			cfg, err := NewConfig(
 				hostFlag,
 				httpPortFlag,
 				grpcPortFlag,
 				zipkinEnabledFlag,
-				promEnabledFlag,
 				fromJSONFileFlag,
 				promTargetFlag,
 			)
@@ -101,8 +94,7 @@ func newCommand(params otelcol.CollectorSettings) *cobra.Command {
 	rootCmd.Flags().IntVar(&grpcPortFlag, "grpc", 4317, "The port number on which we listen for OTLP grpc payloads")
 	rootCmd.Flags().StringVar(&hostFlag, "host", "0.0.0.0", "The host where we expose our OTLP endpoints")
 	rootCmd.Flags().BoolVar(&zipkinEnabledFlag, "enable-zipkin", false, "Enable the zipkin receiver")
-	rootCmd.Flags().BoolVar(&promEnabledFlag, "enable-prom", false, "Enable the prometheus receiver")
 	rootCmd.Flags().StringVar(&fromJSONFileFlag, "from-json-file", "", "The JSON file path exported by JSON exporter")
-	rootCmd.Flags().StringArrayVar(&promTargetFlag, "prom-target", []string{}, `The target endpoints for the prometheus receiver (--prom-target "localhost:9000" --prom-target "http://other-host:9000/custom/prometheus")`)
+	rootCmd.Flags().StringArrayVar(&promTargetFlag, "prom-target", []string{}, `Enable the prometheus receiver and specify the target endpoints for the receiver (--prom-target "localhost:9000" --prom-target "http://other-host:9000/custom/prometheus")`)
 	return rootCmd
 }


### PR DESCRIPTION
related: #288 

This PR removes the `--enable-prom` flag, as specifying `--prom-target` alone is sufficient to enable the Prometheus receiver.
This change also simplifies the documentation and usage.