### PR TITLE
feat: suppress stdout/err and add `--debug-log` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ Usage:
   otel-tui [flags]
 
 Flags:
+      --debug-log                 Enable debug log output to file (/tmp/otel-tui.log)
       --enable-zipkin             Enable the zipkin receiver
+      --from-json-file string     The JSON file path exported by JSON exporter
       --grpc int                  The port number on which we listen for OTLP grpc payloads (default 4317)
   -h, --help                      help for otel-tui
       --host string               The host where we expose our OTLP endpoints (default "0.0.0.0")

--- a/config.go
+++ b/config.go
@@ -29,6 +29,7 @@ type Config struct {
 	FromJSONFile      string
 	PromTarget        []string
 	PromScrapeConfigs []*PromScrapeConfig
+	DebugLogFilePath  string
 }
 
 func NewConfig(
@@ -38,14 +39,16 @@ func NewConfig(
 	enableZipkin bool,
 	fromJSONFile string,
 	promTarget []string,
+	debugLogFilePath string,
 ) (*Config, error) {
 	cfg := &Config{
-		OTLPHost:     otlpHost,
-		OTLPHTTPPort: otlpHTTPPort,
-		OTLPGRPCPort: otlpGRPCPort,
-		EnableZipkin: enableZipkin,
-		FromJSONFile: fromJSONFile,
-		PromTarget:   promTarget,
+		OTLPHost:         otlpHost,
+		OTLPHTTPPort:     otlpHTTPPort,
+		OTLPGRPCPort:     otlpGRPCPort,
+		EnableZipkin:     enableZipkin,
+		FromJSONFile:     fromJSONFile,
+		PromTarget:       promTarget,
+		DebugLogFilePath: debugLogFilePath,
 	}
 
 	if err := cfg.validate(); err != nil {

--- a/config.yml.tpl
+++ b/config.yml.tpl
@@ -42,6 +42,7 @@ processors:
 exporters:
   tui:
     from_json_file: {{ if .FromJSONFile }}true{{else}}false{{end}}
+    debug_log_file_path: '{{ .DebugLogFilePath }}'
 service:
   pipelines:
     traces:

--- a/config_test.go
+++ b/config_test.go
@@ -75,6 +75,7 @@ func TestConfigRenderYml(t *testing.T) {
 			"http://127.0.0.1:1111/custom/prometheus",
 			"example.com:1234/my-metrics",
 		},
+		DebugLogFilePath: "/tmp/otel-tui.log",
 	}
 	want := `yaml:
 receivers:
@@ -119,6 +120,7 @@ processors:
 exporters:
   tui:
     from_json_file: true
+    debug_log_file_path: '/tmp/otel-tui.log'
 service:
   pipelines:
     traces:
@@ -175,6 +177,7 @@ processors:
 exporters:
   tui:
     from_json_file: false
+    debug_log_file_path: ''
 service:
   pipelines:
     traces:

--- a/tuiexporter/config.go
+++ b/tuiexporter/config.go
@@ -4,7 +4,8 @@ import "go.opentelemetry.io/collector/component"
 
 // Config defines configuration for TUI exporter.
 type Config struct {
-	FromJSONFile bool `mapstructure:"from_json_file"`
+	FromJSONFile     bool   `mapstructure:"from_json_file"`
+	DebugLogFilePath string `mapstructure:"debug_log_file_path"`
 }
 
 var _ component.Config = (*Config)(nil)

--- a/tuiexporter/exporter.go
+++ b/tuiexporter/exporter.go
@@ -17,16 +17,21 @@ type tuiExporter struct {
 	app *tui.TUIApp
 }
 
-func newTuiExporter(config *Config) *tuiExporter {
+func newTuiExporter(config *Config) (*tuiExporter, error) {
 	var initialInterval time.Duration
 	if config.FromJSONFile {
 		// FIXME: When reading telemetry from a JSON file on startup, the UI will break
 		//        if it runs at the same time as the UI drawing. As a workaround, wait for a second.
 		initialInterval = 1 * time.Second
 	}
-	return &tuiExporter{
-		app: tui.NewTUIApp(telemetry.NewStore(), initialInterval),
+
+	app, err := tui.NewTUIApp(telemetry.NewStore(), initialInterval, config.DebugLogFilePath)
+	if err != nil {
+		return nil, err
 	}
+	return &tuiExporter{
+		app: app,
+	}, nil
 }
 
 func (e *tuiExporter) pushTraces(_ context.Context, traces ptrace.Traces) error {

--- a/tuiexporter/exporter_test.go
+++ b/tuiexporter/exporter_test.go
@@ -31,7 +31,8 @@ func TestNewTuiExporter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			exporter := newTuiExporter(tt.config)
+			exporter, err := newTuiExporter(tt.config)
+			assert.NoError(t, err)
 			assert.NotNil(t, exporter)
 			assert.NotNil(t, exporter.app)
 			assert.NotNil(t, exporter.app.Store())
@@ -40,33 +41,37 @@ func TestNewTuiExporter(t *testing.T) {
 }
 
 func TestPushTraces(t *testing.T) {
-	exporter := newTuiExporter(&Config{})
+	exporter, err := newTuiExporter(&Config{})
+	assert.NoError(t, err)
 	traces := ptrace.NewTraces()
 
-	err := exporter.pushTraces(context.Background(), traces)
+	err = exporter.pushTraces(context.Background(), traces)
 	assert.NoError(t, err)
 }
 
 func TestPushMetrics(t *testing.T) {
-	exporter := newTuiExporter(&Config{})
+	exporter, err := newTuiExporter(&Config{})
+	assert.NoError(t, err)
 	metrics := pmetric.NewMetrics()
 
-	err := exporter.pushMetrics(context.Background(), metrics)
+	err = exporter.pushMetrics(context.Background(), metrics)
 	assert.NoError(t, err)
 }
 
 func TestPushLogs(t *testing.T) {
-	exporter := newTuiExporter(&Config{})
+	exporter, err := newTuiExporter(&Config{})
+	assert.NoError(t, err)
 	logs := plog.NewLogs()
 
-	err := exporter.pushLogs(context.Background(), logs)
+	err = exporter.pushLogs(context.Background(), logs)
 	assert.NoError(t, err)
 }
 
 func TestStartAndShutdown(t *testing.T) {
-	exporter := newTuiExporter(&Config{})
+	exporter, err := newTuiExporter(&Config{})
+	assert.NoError(t, err)
 
-	err := exporter.Start(context.Background(), nil)
+	err = exporter.Start(context.Background(), nil)
 	assert.NoError(t, err)
 
 	time.Sleep(10 * time.Millisecond)

--- a/tuiexporter/factory.go
+++ b/tuiexporter/factory.go
@@ -34,7 +34,7 @@ func createTraces(ctx context.Context, set exporter.Settings, cfg component.Conf
 	e, err := exporters.LoadOrStore(
 		oCfg,
 		func() (*tuiExporter, error) {
-			return newTuiExporter(oCfg), nil
+			return newTuiExporter(oCfg)
 		},
 		&set.TelemetrySettings,
 	)
@@ -55,7 +55,7 @@ func createMetrics(ctx context.Context, set exporter.Settings, cfg component.Con
 	e, err := exporters.LoadOrStore(
 		oCfg,
 		func() (*tuiExporter, error) {
-			return newTuiExporter(oCfg), nil
+			return newTuiExporter(oCfg)
 		},
 		&set.TelemetrySettings,
 	)
@@ -76,7 +76,7 @@ func createLogs(ctx context.Context, set exporter.Settings, cfg component.Config
 	e, err := exporters.LoadOrStore(
 		oCfg,
 		func() (*tuiExporter, error) {
-			return newTuiExporter(oCfg), nil
+			return newTuiExporter(oCfg)
 		},
 		&set.TelemetrySettings,
 	)

--- a/tuiexporter/internal/tui/component/page.go
+++ b/tuiexporter/internal/tui/component/page.go
@@ -17,7 +17,6 @@ const (
 	PAGE_TIMELINE       = "Timeline"
 	PAGE_TRACE_TOPOLOGY = "TraceTopology"
 	PAGE_LOGS           = "Logs"
-	PAGE_DEBUG_LOG      = "DebugLog"
 	PAGE_METRICS        = "Metrics"
 	PAGE_MODAL          = "Modal"
 
@@ -60,27 +59,14 @@ func NewTUIPages(store *telemetry.Store, setFocusFn func(p tview.Primitive)) *TU
 
 	tp.registerPages(store)
 
+	initClipboard()
+
 	return tp
 }
 
 // GetPages returns the pages
 func (p *TUIPages) GetPages() *tview.Pages {
 	return p.pages
-}
-
-// ToggleLog toggles the log page.
-func (p *TUIPages) ToggleLog() {
-	cname, cpage := p.pages.GetFrontPage()
-	if cname == PAGE_DEBUG_LOG {
-		// hide log
-		p.pages.SendToBack(PAGE_DEBUG_LOG)
-		p.pages.HidePage(PAGE_DEBUG_LOG)
-	} else {
-		// show log
-		p.pages.ShowPage(PAGE_DEBUG_LOG)
-		p.pages.SendToFront(PAGE_DEBUG_LOG)
-		p.setFocusFn(cpage)
-	}
 }
 
 func (p *TUIPages) showModal(current tview.Primitive, text string) *tview.TextView {
@@ -126,10 +112,6 @@ func (p *TUIPages) registerPages(store *telemetry.Store) {
 	modal, _ := p.createModalPage("")
 	p.modal = modal
 	p.pages.AddPage(PAGE_MODAL, modal, true, true)
-
-	logpage := p.createDebugLogPage()
-	p.debuglog = logpage
-	p.pages.AddPage(PAGE_DEBUG_LOG, logpage, true, true)
 
 	traces := p.createTracePage(store)
 	p.traces = traces
@@ -869,25 +851,6 @@ func (p *TUIPages) createLogPage(store *telemetry.Store) *tview.Flex {
 	pageContainer.AddItem(page, 0, DEFAULT_VERTICAL_PROPORTION_LOG_MAIN, true).AddItem(body, 0, DEFAULT_VERTICAL_PROPORTION_LOG_BODY, false)
 
 	return attachTab(attachCommandList(commands, pageContainer), PAGE_LOGS)
-}
-
-func (p *TUIPages) createDebugLogPage() *tview.Flex {
-	logview := tview.NewTextView().SetDynamicColors(true)
-	logview.Box.SetTitle("Log").SetBorder(true)
-	logview.SetChangedFunc(func() {
-		logview.ScrollToEnd()
-	})
-	// file, _ := os.OpenFile("log.log", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-	// log.SetOutput(file)
-	log.SetOutput(logview)
-
-	initClipboard()
-
-	page := tview.NewFlex().SetDirection(tview.FlexRow).
-		AddItem(nil, 0, 7, false).
-		AddItem(logview, 0, 3, false)
-
-	return page
 }
 
 func attachTab(p tview.Primitive, name string) *tview.Flex {

--- a/tuiexporter/internal/tui/component/page.go
+++ b/tuiexporter/internal/tui/component/page.go
@@ -38,7 +38,6 @@ type TUIPages struct {
 	topology          *tview.Flex
 	metrics           *tview.Flex
 	logs              *tview.Flex
-	debuglog          *tview.Flex
 	modal             *tview.Flex
 	clearFns          []func()
 	current           string

--- a/tuiexporter/internal/tui/tui.go
+++ b/tuiexporter/internal/tui/tui.go
@@ -1,6 +1,10 @@
 package tui
 
 import (
+	"io"
+	"log"
+	"os"
+	"syscall"
 	"time"
 
 	"github.com/gdamore/tcell/v2"
@@ -21,8 +25,22 @@ type TUIApp struct {
 }
 
 // NewTUIApp creates a new TUI application.
-func NewTUIApp(store *telemetry.Store, initialInterval time.Duration) *TUIApp {
+func NewTUIApp(store *telemetry.Store, initialInterval time.Duration, debugLogFilePath string) (*TUIApp, error) {
+	if debugLogFilePath != "" {
+		log.Printf("Debug logging enabled, writing to %s", debugLogFilePath)
+		file, err := os.OpenFile(debugLogFilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+		if err != nil {
+			return nil, err
+		}
+		log.SetOutput(file)
+	} else {
+		log.SetOutput(io.Discard) // Disable logging if no file is specified
+	}
+
 	app := tview.NewApplication()
+
+	log.Println("=== otel-tui exporter initialized ===")
+
 	tpages := component.NewTUIPages(store, func(p tview.Primitive) {
 		app.SetFocus(p)
 	})
@@ -38,11 +56,16 @@ func NewTUIApp(store *telemetry.Store, initialInterval time.Duration) *TUIApp {
 
 	app.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
 		switch event.Key() {
-		case tcell.KeyF12:
-			tpages.ToggleLog()
-			return nil
 		case tcell.KeyTab:
 			tpages.TogglePage()
+			return nil
+		case tcell.KeyCtrlC:
+			// Send SGITERM to self on Ctrl+C to ensure global signal handlers are triggered
+			// Prevents the need for pressing Ctrl+C twice due to tview consuming the first Ctrl+C
+			p, err := os.FindProcess(os.Getpid())
+			if err == nil {
+				_ = p.Signal(syscall.SIGTERM)
+			}
 			return nil
 		}
 		return event
@@ -50,7 +73,7 @@ func NewTUIApp(store *telemetry.Store, initialInterval time.Duration) *TUIApp {
 
 	tapp.refreshedAt = time.Now()
 
-	return tapp
+	return tapp, nil
 }
 
 // Store returns the store

--- a/tuiexporter/internal/tui/tui.go
+++ b/tuiexporter/internal/tui/tui.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"path/filepath"
 	"syscall"
 	"time"
 
@@ -28,7 +29,7 @@ type TUIApp struct {
 func NewTUIApp(store *telemetry.Store, initialInterval time.Duration, debugLogFilePath string) (*TUIApp, error) {
 	if debugLogFilePath != "" {
 		log.Printf("Debug logging enabled, writing to %s", debugLogFilePath)
-		file, err := os.OpenFile(debugLogFilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+		file, err := os.OpenFile(filepath.Clean(debugLogFilePath), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This PR suppresses all stdout/stderr output from OpenTelemetry Collector components by default, and adds a `--debug-log` option to redirect logs to a file (`/tmp/otel-tui.log`).
It also fixes an issue where the application required pressing Ctrl+C twice to exit.

This change addresses cases like #289, where unexpected output to stdout can corrupt the TUI screen.