### PR TITLE
feat(metric): Parse params in HTTP URL for Prometheus

### DIFF
--- a/config.yml.tpl
+++ b/config.yml.tpl
@@ -27,6 +27,15 @@ receivers:
 {{- if ne $config.Scheme ""}}
           scheme: '{{ $config.Scheme -}}'
 {{- end}}
+{{- if $config.Params }}
+          params:
+{{- range $param := $config.Params }}
+            {{ $param.Key }}:
+{{- range $v := $param.Values }}
+              - '{{ $v }}'
+{{- end }}
+{{- end }}
+{{- end }}
           static_configs:
             - targets:
               - '{{ $config.Target -}}'


### PR DESCRIPTION
With this change, I can now scrape archgw like this:

```bash
otel-tui --prom-target http://localhost:19901/stats?format=prometheus
```

<img width="1508" alt="Screenshot 2025-06-15 at 4 02 49 PM" src="https://github.com/user-attachments/assets/eac83c90-2262-46df-9efb-38fb75670deb" />
