### PR TITLE
chore(goreleaser): remove i386 from build target

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -14,6 +14,9 @@ builds:
       - linux
       - windows
       - darwin
+    goarch:
+      - amd64
+      - arm64
 
 archives:
   - format: tar.gz


### PR DESCRIPTION
release action is failing due to the following erorr:

```
error=failed to build for windows_386: exit status 1: # go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp/internal/envconfig
```

https://github.com/ymtdzzz/otel-tui/actions/runs/18298968842/job/52103991650

This is not a fundamental fix, but since I believe there are few users of i386, I'll exclude it from the build targets.