### PR TITLE
feat: add disable-internal-metrics option

### DIFF
--- a/config.go
+++ b/config.go
@@ -29,14 +29,15 @@ type PromScrapeConfig struct {
 }
 
 type Config struct {
-	OTLPHost          string
-	OTLPHTTPPort      int
-	OTLPGRPCPort      int
-	EnableZipkin      bool
-	FromJSONFile      string
-	PromTarget        []string
-	PromScrapeConfigs []*PromScrapeConfig
-	DebugLogFilePath  string
+	OTLPHost               string
+	OTLPHTTPPort           int
+	OTLPGRPCPort           int
+	EnableZipkin           bool
+	FromJSONFile           string
+	PromTarget             []string
+	PromScrapeConfigs      []*PromScrapeConfig
+	DebugLogFilePath       string
+	DisableInternalMetrics bool
 }
 
 func NewConfig(
@@ -47,15 +48,17 @@ func NewConfig(
 	fromJSONFile string,
 	promTarget []string,
 	debugLogFilePath string,
+	disableInternalMetrics bool,
 ) (*Config, error) {
 	cfg := &Config{
-		OTLPHost:         otlpHost,
-		OTLPHTTPPort:     otlpHTTPPort,
-		OTLPGRPCPort:     otlpGRPCPort,
-		EnableZipkin:     enableZipkin,
-		FromJSONFile:     fromJSONFile,
-		PromTarget:       promTarget,
-		DebugLogFilePath: debugLogFilePath,
+		OTLPHost:               otlpHost,
+		OTLPHTTPPort:           otlpHTTPPort,
+		OTLPGRPCPort:           otlpGRPCPort,
+		EnableZipkin:           enableZipkin,
+		FromJSONFile:           fromJSONFile,
+		PromTarget:             promTarget,
+		DebugLogFilePath:       debugLogFilePath,
+		DisableInternalMetrics: disableInternalMetrics,
 	}
 
 	if err := cfg.validate(); err != nil {

--- a/config.yml.tpl
+++ b/config.yml.tpl
@@ -53,6 +53,11 @@ exporters:
     from_json_file: {{ if .FromJSONFile }}true{{else}}false{{end}}
     debug_log_file_path: '{{ .DebugLogFilePath }}'
 service:
+{{- if .DisableInternalMetrics}}
+  telemetry:
+    metrics:
+      level: none
+{{- end}}
   pipelines:
     traces:
       receivers:

--- a/config_test.go
+++ b/config_test.go
@@ -117,7 +117,8 @@ func TestConfigRenderYml(t *testing.T) {
 			"http://exporterserver:9199/ups_metrics?ups=secondary&server=nutserver2",
 			"http://source-prometheus-1:9090/federate?match[]={job=\"prometheus\"}&match[]={__name__=~\"job:.*\"}",
 		},
-		DebugLogFilePath: "/tmp/otel-tui.log",
+		DebugLogFilePath:       "/tmp/otel-tui.log",
+		DisableInternalMetrics: true,
 	}
 	want := `yaml:
 receivers:
@@ -193,6 +194,9 @@ exporters:
     from_json_file: true
     debug_log_file_path: '/tmp/otel-tui.log'
 service:
+  telemetry:
+    metrics:
+      level: none
   pipelines:
     traces:
       receivers:

--- a/main.go
+++ b/main.go
@@ -52,6 +52,7 @@ func newCommand(params otelcol.CollectorSettings) *cobra.Command {
 		promTargetFlag             []string
 		fromJSONFileFlag           string
 		debugLogFlag               bool
+		disableInternalMetricsFlag bool
 	)
 
 	rootCmd := &cobra.Command{
@@ -72,6 +73,7 @@ func newCommand(params otelcol.CollectorSettings) *cobra.Command {
 				fromJSONFileFlag,
 				promTargetFlag,
 				logPath,
+				disableInternalMetricsFlag,
 			)
 
 			if err != nil {
@@ -107,6 +109,7 @@ func newCommand(params otelcol.CollectorSettings) *cobra.Command {
 	rootCmd.Flags().StringVar(&fromJSONFileFlag, "from-json-file", "", "The JSON file path exported by JSON exporter")
 	rootCmd.Flags().StringArrayVar(&promTargetFlag, "prom-target", []string{}, `Enable the prometheus receiver and specify the target endpoints for the receiver (--prom-target "localhost:9000" --prom-target "http://other-host:9000/custom/prometheus")`)
 	rootCmd.Flags().BoolVar(&debugLogFlag, "debug-log", false, "Enable debug log output to file (/tmp/otel-tui.log)")
+	rootCmd.Flags().BoolVar(&disableInternalMetricsFlag, "disable-internal-metrics", false, "Disable the collector's internal metrics telemetry reporting")
 	return rootCmd
 }
 


### PR DESCRIPTION
Simply to avoid port conflicts exposing the prometheus endpoint.