### PR TITLE
fix: chart every data point of a metric, not just the last one

### DIFF
--- a/tuiexporter/internal/tui/component/page/metric/chart.go
+++ b/tuiexporter/internal/tui/component/page/metric/chart.go
@@ -191,37 +191,24 @@ func (c *chart) drawMetricNumberChart(m *telemetry.MetricData) layout.KeyMaps {
 	support := true
 	start := time.Unix(1<<63-62135596801, 999999999)
 	end := time.Unix(0, 0)
+	// Register a datapoint as one sample of the series identified by the given
+	// attribute key and value.
+	addToDataMap := func(k, vstr string, dp *pmetric.NumberDataPoint) {
+		if _, ok := dataMap[k]; !ok {
+			attrkeys = append(attrkeys, k)
+			dataMap[k] = map[string][]*pmetric.NumberDataPoint{}
+		}
+		dataMap[k][vstr] = append(dataMap[k][vstr], dp)
+	}
+
 	for _, m := range ms {
-		var (
-			attrs map[string]any
-			dp    pmetric.NumberDataPoint
-		)
+		var dps pmetric.NumberDataPointSlice
 
 		switch m.Metric.Type() {
 		case pmetric.MetricTypeGauge:
-			for dpi := 0; dpi < m.Metric.Gauge().DataPoints().Len(); dpi++ {
-				dp = m.Metric.Gauge().DataPoints().At(dpi)
-				attrs = dp.Attributes().AsRaw()
-				dpts := dp.Timestamp().AsTime()
-				if dpts.Before(start) {
-					start = dpts
-				}
-				if dpts.After(end) {
-					end = dpts
-				}
-			}
+			dps = m.Metric.Gauge().DataPoints()
 		case pmetric.MetricTypeSum:
-			for dpi := 0; dpi < m.Metric.Sum().DataPoints().Len(); dpi++ {
-				dp = m.Metric.Sum().DataPoints().At(dpi)
-				attrs = dp.Attributes().AsRaw()
-				dpts := dp.Timestamp().AsTime()
-				if dpts.Before(start) {
-					start = dpts
-				}
-				if dpts.After(end) {
-					end = dpts
-				}
-			}
+			dps = m.Metric.Sum().DataPoints()
 		default:
 			support = false
 		}
@@ -229,7 +216,28 @@ func (c *chart) drawMetricNumberChart(m *telemetry.MetricData) layout.KeyMaps {
 			break
 		}
 
-		if len(attrs) > 0 {
+		// Every datapoint must be registered here: a single metric commonly carries
+		// one datapoint per attribute value (e.g. one per dotnet.gc.heap.generation),
+		// and each of those is a separate series on the chart.
+		for dpi := 0; dpi < dps.Len(); dpi++ {
+			// Bind a fresh variable per iteration so the pointers kept in dataMap
+			// don't all alias the same datapoint.
+			dp := dps.At(dpi)
+
+			dpts := dp.Timestamp().AsTime()
+			if dpts.Before(start) {
+				start = dpts
+			}
+			if dpts.After(end) {
+				end = dpts
+			}
+
+			attrs := dp.Attributes().AsRaw()
+			if len(attrs) == 0 {
+				addToDataMap("N/A", "N/A", &dp)
+				continue
+			}
+
 			// sort keys
 			keys := make([]string, 0, len(attrs))
 			for k := range attrs {
@@ -238,30 +246,7 @@ func (c *chart) drawMetricNumberChart(m *telemetry.MetricData) layout.KeyMaps {
 			sort.Strings(keys)
 			for _, k := range keys {
 				v := attrs[k]
-				vstr := fmt.Sprintf("%s", v)
-				if attrkey, ok := dataMap[k]; ok {
-					if _, ok := attrkey[vstr]; ok {
-						dataMap[k][vstr] = append(dataMap[k][vstr], &dp)
-					} else {
-						dataMap[k][vstr] = []*pmetric.NumberDataPoint{&dp}
-					}
-				} else {
-					attrkeys = append(attrkeys, k)
-					dataMap[k] = map[string][]*pmetric.NumberDataPoint{vstr: {&dp}}
-				}
-			}
-		} else {
-			k := "N/A"
-			vstr := "N/A"
-			if attrkey, ok := dataMap[k]; ok {
-				if _, ok := attrkey[vstr]; ok {
-					dataMap[k][vstr] = append(dataMap[k][vstr], &dp)
-				} else {
-					dataMap[k][vstr] = []*pmetric.NumberDataPoint{&dp}
-				}
-			} else {
-				attrkeys = append(attrkeys, k)
-				dataMap[k] = map[string][]*pmetric.NumberDataPoint{vstr: {&dp}}
+				addToDataMap(k, fmt.Sprintf("%s", v), &dp)
 			}
 		}
 	}

--- a/tuiexporter/internal/tui/component/page/metric/chart_test.go
+++ b/tuiexporter/internal/tui/component/page/metric/chart_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ymtdzzz/otel-tui/tuiexporter/internal/test"
 	"github.com/ymtdzzz/otel-tui/tuiexporter/internal/tui/component/layout"
 	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
 )
 
 func TestDrawMetricHistogramChart(t *testing.T) {
@@ -153,4 +154,86 @@ func TestDrawMetricNumberChartWithManyDataPoints(t *testing.T) {
 	tv := legend.GetItem(0).(*tview.TextView)
 	lines := strings.Count(tv.GetText(false), "\n") + 1
 	assert.Equal(t, dpCount, lines)
+}
+
+// generationMetricPayload builds a single metric carrying one data point per given
+// attribute value, mirroring how the .NET runtime reports metrics such as
+// dotnet.gc.collections (one data point per dotnet.gc.heap.generation).
+func generationMetricPayload(t *testing.T, ts time.Time, isSum bool, gens []string) (pmetric.Metrics, *telemetry.MetricData) {
+	t.Helper()
+
+	payload, m := test.GenerateOTLPGaugeMetricsPayload(t, 1, []int{1}, [][]int{{1}})
+	metric := payload.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0)
+
+	var dps pmetric.NumberDataPointSlice
+	if isSum {
+		dps = metric.SetEmptySum().DataPoints()
+	} else {
+		dps = metric.SetEmptyGauge().DataPoints()
+	}
+	for i, gen := range gens {
+		dp := dps.AppendEmpty()
+		dp.SetIntValue(int64(i + 1))
+		dp.Attributes().PutStr("dotnet.gc.heap.generation", gen)
+		dp.SetTimestamp(pcommon.NewTimestampFromTime(ts))
+	}
+
+	return payload, &telemetry.MetricData{
+		Metric:         m.Metrics[0],
+		ResourceMetric: m.RMetrics[0],
+	}
+}
+
+// A single metric carrying several data points that differ only by attribute value
+// must produce one series per value, not just one.
+func TestDrawMetricNumberChartWithMultipleDataPointsInOneMetric(t *testing.T) {
+	tests := []struct {
+		name  string
+		isSum bool
+		gens  []string
+	}{
+		{
+			// dotnet.gc.last_collection.heap.size
+			name:  "gauge",
+			isSum: false,
+			gens:  []string{"gen0", "gen1", "gen2", "loh", "poh"},
+		},
+		{
+			// dotnet.gc.collections
+			name:  "sum",
+			isSum: true,
+			gens:  []string{"gen0", "gen1", "gen2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClock := clockwork.NewFakeClockAt(time.Date(2025, 11, 9, 12, 15, 0, 0, time.UTC))
+			store := telemetry.NewStore(mockClock)
+
+			// Two exports of the same metric, so the series must accumulate over time
+			// rather than overwrite each other.
+			var selected *telemetry.MetricData
+			for i := range 2 {
+				payload, md := generationMetricPayload(
+					t, mockClock.Now().Add(time.Duration(i)*time.Second), tt.isSum, tt.gens,
+				)
+				store.AddMetric(&payload)
+				selected = md
+			}
+
+			chart := newChart(layout.NewCommandList(), store, []*layout.ResizeManager{})
+			chart.update(selected)
+
+			legend := chart.ch.GetItem(1).(*tview.Flex)
+			tv := legend.GetItem(0).(*tview.TextView)
+			text := tv.GetText(false)
+
+			// One legend line per generation, regardless of the order they arrive in.
+			assert.Equal(t, len(tt.gens), strings.Count(text, "\n")+1)
+			for _, gen := range tt.gens {
+				assert.Contains(t, text, "dotnet.gc.heap.generation: "+gen)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Gauge and Sum metrics were charted using only **one** data point per metric,
so any metric whose data points differ only by attribute value collapsed to a
single series.

This is easy to hit with .NET runtime metrics: `dotnet.gc.collections` and
`dotnet.gc.last_collection.heap.size` each report one data point per
`dotnet.gc.heap.generation`, so only a single generation was plotted — even
though the Metrics table's "Data Point Count" column correctly showed all of
them arriving.

## Root cause

In `drawMetricNumberChart`, `attrs` and `dp` were declared *outside* the
per-data-point loop, and the code inserting into `dataMap` ran *after* that
loop had already finished. Each metric therefore registered only its final
data point, along with only that data point's attributes. `&dp` also took the
address of a single reused variable.

## Changes

- Move the `dataMap` grouping inside the data point loop so every data point
  is registered.
- Bind `dp` per iteration, so stored pointers no longer alias one variable.
- Hoist the `Gauge()`/`Sum()` slice selection out of the type switch and
  collapse the four duplicated insert branches into one `addToDataMap` helper
  (net −55 lines).

Deliberately unchanged:

- The `[n / m]` chart title pages over attribute **keys**, not data points, so
  it correctly stays `[1 / 1]` for these metrics. What changes is that the
  legend and plot gain one coloured line per generation.
- `getDataToDraw`, its interpolation, and `lineColors` already handle multiple
  series and needed no edits.
- Histogram rendering (`drawMetricHistogramChart`) already iterated all data
  points and is untouched.

## Testing

Added `TestDrawMetricNumberChartWithMultipleDataPointsInOneMetric`, covering
both the Gauge shape (`gen0`/`gen1`/`gen2`/`loh`/`poh`) and the Sum shape
(`gen0`/`gen1`/`gen2`), across two exports to confirm series accumulate over
time. Assertions are order-independent.

Confirmed to be a real regression test by reverting `chart.go` and re-running:
the legend contained 1 line instead of 3/5, retaining only the last data point.

The existing `TestDrawMetricNumberChartWithManyDataPoints` could not catch this
bug — it builds N separate payloads of one data point each, so the "keep the
last data point" path still produced N series. Multiple data points *within a
single metric* were never exercised.

Verified end-to-end against a live .NET app: all generations now appear in the
legend, matching the "Data Point Count" column and the Details pane.
