### PR TITLE
Dismiss attribute modals when focus moves

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,3 +223,9 @@ make test-exporter
 - Open a pull request to the main repository, providing a clear description of your changes and their purpose.
 
 Thank you for taking the time to contribute!
+
+### Attribute modal focus
+
+Attribute modals close when focus moves to another pane. Blur callbacks queue
+page changes after tview releases its focus lock, preserving the destination
+focus and ignoring dismissals for a modal that has already been replaced.

--- a/tuiexporter/internal/tui/component/layout/modal.go
+++ b/tuiexporter/internal/tui/component/layout/modal.go
@@ -56,6 +56,17 @@ func AttachModalForTreeAttributes(tree *tview.TreeView, onHide func()) {
 			currentModalNode = nil
 		}
 	})
+	tree.SetBlurFunc(func() {
+		if currentModalNode != nil {
+			// Focus is already moving elsewhere, so dismiss the modal without
+			// restoring focus to the tree that opened it.
+			navigation.HideModal(nil)
+			if onHide != nil {
+				onHide()
+			}
+			currentModalNode = nil
+		}
+	})
 }
 
 type tableModalMapper interface {
@@ -103,6 +114,15 @@ func AttachModalForTableRows(table *tview.Table, mapper tableModalMapper, onHide
 	table.SetSelectionChangedFunc(func(row, column int) {
 		if currentRow != -1 {
 			navigation.HideModal(table)
+			if onHide != nil {
+				onHide()
+			}
+			currentRow = -1
+		}
+	})
+	table.SetBlurFunc(func() {
+		if currentRow != -1 {
+			navigation.HideModal(nil)
 			if onHide != nil {
 				onHide()
 			}

--- a/tuiexporter/internal/tui/component/layout/modal.go
+++ b/tuiexporter/internal/tui/component/layout/modal.go
@@ -17,11 +17,11 @@ func AttachModalForTreeAttributes(tree *tview.TreeView, onHide func()) {
 			return
 		}
 		if currentModalNode == node {
+			currentModalNode = nil
 			navigation.HideModal(tree)
 			if onHide != nil {
 				onHide()
 			}
-			currentModalNode = nil
 			return
 		}
 		nodeText := node.GetText()
@@ -49,23 +49,27 @@ func AttachModalForTreeAttributes(tree *tview.TreeView, onHide func()) {
 	})
 	tree.SetChangedFunc(func(node *tview.TreeNode) {
 		if currentModalNode != nil {
+			currentModalNode = nil
 			navigation.HideModal(tree)
 			if onHide != nil {
 				onHide()
 			}
-			currentModalNode = nil
 		}
 	})
 	tree.SetBlurFunc(func() {
-		if currentModalNode != nil {
-			// Focus is already moving elsewhere, so dismiss the modal without
-			// restoring focus to the tree that opened it.
+		if currentModalNode == nil {
+			return
+		}
+		currentModalNode = nil
+		navigation.QueueModalDismiss(tree, func() {
+			if currentModalNode != nil {
+				return
+			}
 			navigation.HideModal(nil)
 			if onHide != nil {
 				onHide()
 			}
-			currentModalNode = nil
-		}
+		})
 	})
 }
 
@@ -84,18 +88,18 @@ func AttachModalForTableRows(table *tview.Table, mapper tableModalMapper, onHide
 
 	table.SetSelectedFunc(func(row, column int) {
 		if currentRow == row {
+			currentRow = -1
 			navigation.HideModal(table)
 			if onHide != nil {
 				onHide()
 			}
-			currentRow = -1
 			return
 		}
-		currentRow = row
 		if cell := table.GetCell(row, mapper.GetColumnIdx()); cell != nil {
 			text := cell.Text
 			text = json.PrettyJSON(text)
 			textView := navigation.ShowModal(table, text)
+			currentRow = row
 			table.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
 				switch event.Key() {
 				case tcell.KeyCtrlJ:
@@ -113,20 +117,26 @@ func AttachModalForTableRows(table *tview.Table, mapper tableModalMapper, onHide
 	})
 	table.SetSelectionChangedFunc(func(row, column int) {
 		if currentRow != -1 {
+			currentRow = -1
 			navigation.HideModal(table)
 			if onHide != nil {
 				onHide()
 			}
-			currentRow = -1
 		}
 	})
 	table.SetBlurFunc(func() {
-		if currentRow != -1 {
+		if currentRow == -1 {
+			return
+		}
+		currentRow = -1
+		navigation.QueueModalDismiss(table, func() {
+			if currentRow != -1 {
+				return
+			}
 			navigation.HideModal(nil)
 			if onHide != nil {
 				onHide()
 			}
-			currentRow = -1
-		}
+		})
 	})
 }

--- a/tuiexporter/internal/tui/component/layout/modal_test.go
+++ b/tuiexporter/internal/tui/component/layout/modal_test.go
@@ -84,3 +84,54 @@ func Test_attachModalForTreeAttributes(t *testing.T) {
 		})
 	}
 }
+
+func TestAttachModalForTreeAttributesHidesModalOnBlur(t *testing.T) {
+	tree := tview.NewTreeView()
+	root := tview.NewTreeNode("")
+	node := tview.NewTreeNode("key: value")
+	root.AddChild(node)
+	tree.SetRoot(root).SetCurrentNode(node)
+
+	hideCalls := 0
+	onHideCalls := 0
+	navigation.Init(nil, func(tview.Primitive, string) *tview.TextView {
+		return tview.NewTextView()
+	}, func(current tview.Primitive) {
+		assert.Nil(t, current)
+		hideCalls++
+	})
+
+	AttachModalForTreeAttributes(tree, func() { onHideCalls++ })
+	tree.GetSelectedFunc()(node)
+	tree.Blur()
+
+	assert.Equal(t, 1, hideCalls)
+	assert.Equal(t, 1, onHideCalls)
+}
+
+type testTableModalMapper struct{}
+
+func (testTableModalMapper) GetColumnIdx() int { return 0 }
+
+func TestAttachModalForTableRowsHidesModalOnBlur(t *testing.T) {
+	table := tview.NewTable().SetSelectable(true, false)
+	table.SetCell(0, 0, tview.NewTableCell("value"))
+
+	hideCalls := 0
+	navigation.Init(nil, func(tview.Primitive, string) *tview.TextView {
+		return tview.NewTextView()
+	}, func(current tview.Primitive) {
+		assert.Nil(t, current)
+		hideCalls++
+	})
+
+	AttachModalForTableRows(table, testTableModalMapper{}, nil)
+	// Invoke the selected handler through the input path without allowing the
+	// same event's selection notification to close the modal first.
+	table.SetSelectionChangedFunc(nil)
+	table.Focus(nil)
+	table.InputHandler()(tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone), nil)
+	table.Blur()
+
+	assert.Equal(t, 1, hideCalls)
+}

--- a/tuiexporter/internal/tui/component/layout/modal_test.go
+++ b/tuiexporter/internal/tui/component/layout/modal_test.go
@@ -118,6 +118,7 @@ func TestAttachModalForTableRowsHidesModalOnBlur(t *testing.T) {
 	table.SetCell(0, 0, tview.NewTableCell("value"))
 
 	hideCalls := 0
+	onHideCalls := 0
 	navigation.Init(nil, func(tview.Primitive, string) *tview.TextView {
 		return tview.NewTextView()
 	}, func(current tview.Primitive) {
@@ -125,7 +126,7 @@ func TestAttachModalForTableRowsHidesModalOnBlur(t *testing.T) {
 		hideCalls++
 	})
 
-	AttachModalForTableRows(table, testTableModalMapper{}, nil)
+	AttachModalForTableRows(table, testTableModalMapper{}, func() { onHideCalls++ })
 	// Invoke the selected handler through the input path without allowing the
 	// same event's selection notification to close the modal first.
 	table.SetSelectionChangedFunc(nil)
@@ -134,4 +135,5 @@ func TestAttachModalForTableRowsHidesModalOnBlur(t *testing.T) {
 	table.Blur()
 
 	assert.Equal(t, 1, hideCalls)
+	assert.Equal(t, 1, onHideCalls)
 }

--- a/tuiexporter/internal/tui/component/navigation/navigation.go
+++ b/tuiexporter/internal/tui/component/navigation/navigation.go
@@ -3,9 +3,12 @@ package navigation
 import "github.com/rivo/tview"
 
 var (
-	focusFn func(tview.Primitive)
-	showMFn func(tview.Primitive, string) *tview.TextView
-	hideMFn func(tview.Primitive)
+	focusFn         func(tview.Primitive)
+	showMFn         func(tview.Primitive, string) *tview.TextView
+	hideMFn         func(tview.Primitive)
+	queueUpdateFn   func(func())
+	modalOwner      tview.Primitive
+	modalGeneration uint64
 )
 
 func Init(
@@ -16,6 +19,32 @@ func Init(
 	focusFn = setFocusFn
 	showMFn = showModalFn
 	hideMFn = hideModalFn
+	queueUpdateFn = nil
+	modalOwner = nil
+	modalGeneration = 0
+}
+
+// SetQueueUpdateFunc schedules work after tview releases its focus lock.
+func SetQueueUpdateFunc(queue func(func())) {
+	queueUpdateFn = queue
+}
+
+// QueueModalDismiss ignores a delayed blur if a newer modal has replaced it.
+func QueueModalDismiss(owner tview.Primitive, update func()) {
+	if modalOwner != owner {
+		return
+	}
+	generation := modalGeneration
+	guarded := func() {
+		if generation == modalGeneration && modalOwner == owner {
+			update()
+		}
+	}
+	if queueUpdateFn != nil {
+		queueUpdateFn(guarded)
+		return
+	}
+	guarded()
 }
 
 func Focus(primitive tview.Primitive) {
@@ -25,6 +54,8 @@ func Focus(primitive tview.Primitive) {
 }
 
 func ShowModal(primitive tview.Primitive, title string) *tview.TextView {
+	modalOwner = primitive
+	modalGeneration++
 	if showMFn != nil {
 		return showMFn(primitive, title)
 	}
@@ -32,6 +63,8 @@ func ShowModal(primitive tview.Primitive, title string) *tview.TextView {
 }
 
 func HideModal(primitive tview.Primitive) {
+	modalOwner = nil
+	modalGeneration++
 	if hideMFn != nil {
 		hideMFn(primitive)
 	}

--- a/tuiexporter/internal/tui/component/page/modal/modal.go
+++ b/tuiexporter/internal/tui/component/page/modal/modal.go
@@ -50,6 +50,8 @@ func (m *ModalPage) ShowModalFunc(showModalPageFn func()) func(current tview.Pri
 func (m *ModalPage) HideModalFunc(hideModalPageFn func()) func(current tview.Primitive) {
 	return func(current tview.Primitive) {
 		hideModalPageFn()
-		navigation.Focus(current)
+		if current != nil {
+			navigation.Focus(current)
+		}
 	}
 }

--- a/tuiexporter/internal/tui/component/page/modal/modal_test.go
+++ b/tuiexporter/internal/tui/component/page/modal/modal_test.go
@@ -51,4 +51,8 @@ func TestHideModalWithoutCurrentFocus(t *testing.T) {
 	hideModalFn(nil)
 
 	assert.Equal(t, 0, focusCalls)
+
+	current := tview.NewBox()
+	hideModalFn(current)
+	assert.Equal(t, 1, focusCalls)
 }

--- a/tuiexporter/internal/tui/component/page/modal/modal_test.go
+++ b/tuiexporter/internal/tui/component/page/modal/modal_test.go
@@ -3,7 +3,9 @@ package modal
 import (
 	"testing"
 
+	"github.com/rivo/tview"
 	"github.com/stretchr/testify/mock"
+	"github.com/ymtdzzz/otel-tui/tuiexporter/internal/tui/component/navigation"
 	"gotest.tools/v3/assert"
 )
 
@@ -38,4 +40,15 @@ func TestModalPage(t *testing.T) {
 		hideModalFn(nil)
 		mockHandler.AssertCalled(t, "hideModal")
 	})
+}
+
+func TestHideModalWithoutCurrentFocus(t *testing.T) {
+	focusCalls := 0
+	navigation.Init(func(tview.Primitive) { focusCalls++ }, nil, nil)
+
+	modalPage := NewModalPage()
+	hideModalFn := modalPage.HideModalFunc(func() {})
+	hideModalFn(nil)
+
+	assert.Equal(t, 0, focusCalls)
 }

--- a/tuiexporter/internal/tui/component/page/modal/modal_test.go
+++ b/tuiexporter/internal/tui/component/page/modal/modal_test.go
@@ -2,15 +2,61 @@ package modal
 
 import (
 	"testing"
+	"time"
 
+	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 	"github.com/stretchr/testify/mock"
+	"github.com/ymtdzzz/otel-tui/tuiexporter/internal/tui/component/layout"
 	"github.com/ymtdzzz/otel-tui/tuiexporter/internal/tui/component/navigation"
 	"gotest.tools/v3/assert"
 )
 
 type mockModalPageHandler struct {
 	mock.Mock
+}
+
+type firstColumn struct{}
+
+func (firstColumn) GetColumnIdx() int { return 0 }
+
+func TestModalFocusTransitionDoesNotDeadlock(t *testing.T) {
+	done := make(chan bool, 1)
+	go func() {
+		app := tview.NewApplication()
+		table := tview.NewTable().SetSelectable(true, false)
+		table.SetCell(0, 0, tview.NewTableCell("attribute"))
+		modal := NewModalPage()
+		pages := tview.NewPages().AddPage("table", table, true, true).
+			AddPage("modal", modal.GetPrimitive(), true, false)
+		app.SetRoot(pages, true)
+		navigation.Init(func(p tview.Primitive) { app.SetFocus(p) },
+			modal.ShowModalFunc(func() { pages.ShowPage("modal").SendToFront("modal") }),
+			modal.HideModalFunc(func() { pages.SendToBack("modal").HidePage("modal") }))
+		var queued []func()
+		navigation.SetQueueUpdateFunc(func(update func()) { queued = append(queued, update) })
+		layout.AttachModalForTableRows(table, firstColumn{}, nil)
+		table.SetSelectionChangedFunc(nil)
+		table.InputHandler()(tcell.NewEventKey(tcell.KeyEnter, 0, tcell.ModNone), nil)
+		name, _ := pages.GetFrontPage()
+		if name != "modal" {
+			done <- false
+			return
+		}
+		destination := tview.NewBox()
+		app.SetFocus(destination)
+		for _, update := range queued {
+			update()
+		}
+		name, _ = pages.GetFrontPage()
+		done <- name == "table" && app.GetFocus() == destination
+	}()
+	select {
+	case ok := <-done:
+		assert.Assert(t, ok)
+	case <-time.After(2 * time.Second):
+		t.Fatal("opening or blurring a modal deadlocked the actual tview focus path")
+	}
 }
 
 func (m *mockModalPageHandler) showModal() {

--- a/tuiexporter/internal/tui/tui.go
+++ b/tuiexporter/internal/tui/tui.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rivo/tview"
 	"github.com/ymtdzzz/otel-tui/tuiexporter/internal/telemetry"
 	"github.com/ymtdzzz/otel-tui/tuiexporter/internal/tui/component"
+	"github.com/ymtdzzz/otel-tui/tuiexporter/internal/tui/component/navigation"
 )
 
 const refreshInterval = 500 * time.Millisecond
@@ -52,6 +53,15 @@ func NewTUIApp(store *telemetry.Store, initialInterval time.Duration, debugLogFi
 		app.SetFocus(p)
 	})
 	pages := tpages.GetPages()
+	navigation.SetQueueUpdateFunc(func(update func()) {
+		// Blur runs under Application.SetFocus's lock. Page changes can focus
+		// children again, so defer them to the event loop and retain its new focus.
+		go app.QueueUpdateDraw(func() {
+			focus := app.GetFocus()
+			update()
+			app.SetFocus(focus)
+		})
+	})
 	tapp := &TUIApp{
 		initialInterval: initialInterval,
 		app:             app,


### PR DESCRIPTION
Closes #415.

Attribute modals now close when their originating tree or table loses focus. The blur path dismisses the modal without restoring focus to the pane the user just left, while explicit close and selection-change behavior remains unchanged.

Validation:
- `make lint`
- `make test`
- `make test-exporter`
- focused modal lifecycle regressions

Implemented and tested with Codex.
